### PR TITLE
Fallback to latest Go if GOROOT not existed.

### DIFF
--- a/lib/templates/deploy.batch.go.template
+++ b/lib/templates/deploy.batch.go.template
@@ -12,8 +12,9 @@ IF /I "%IN_PLACE_DEPLOYMENT%" EQU "1" (
 )
 
 ECHO Prepare workspace
-IF "%GOROOT%" == "" (
+IF NOT EXIST "%GOROOT%" (
   IF DEFINED GO_WEB_CONFIG_TEMPLATE (
+    :: it is running on Azure
     CALL PowerShell -NoProfile -NoLogo -ExecutionPolicy unrestricted -Command "&('%SELECT_LATEST_VERSION_CMD%') '%ProgramW6432%\Go' '%DEPLOYMENT_TEMP%\___GO_RUNTIME.tmp'"
     IF !ERRORLEVEL! NEQ 0 goto error
     
@@ -30,8 +31,9 @@ IF "%GOROOT%" == "" (
   ) 
 
   IF NOT DEFINED GO_WEB_CONFIG_TEMPLATE (
-    ECHO Default to Go 1.5
-    SET GOROOT=%ProgramW6432%\Go\1.5
+    :: Non-Azure environment, GOROOT must be defined
+    ECHO Go not found, please defined GOROOT environment variable
+    goto error
   )
 )
 ECHO GOROOT %GOROOT%


### PR DESCRIPTION
* GOROOT not set, use latest Go
* User defined GOROOT, but not existed (e.g version too old got removed to free spaces), use latest Go