### PR TITLE
Ensuring SCM_DNVM_PS_PATH is set

### DIFF
--- a/lib/templates/deploy.batch.aspnet.5.template
+++ b/lib/templates/deploy.batch.aspnet.5.template
@@ -16,6 +16,10 @@ IF "%DEPLOYMENT_TARGET:~-1%"=="\" (
     SET DEPLOYMENT_TARGET=%DEPLOYMENT_TARGET:~0,-1%
 )
 
+:: Set DNVM Powershell script when not set
+IF "%SCM_DNVM_PS_PATH%"=="" (
+    SET SCM_DNVM_PS_PATH="%USERPROFILE%\.dnx\bin\dnvm.ps1"
+)
 
 :: 1. Set DNX Path
 set DNVM_CMD_PATH_FILE="%USERPROFILE%\.dnx\temp-set-envvars.cmd"


### PR DESCRIPTION
When deploy.cmd is run locally the SCM_DNVM_PS_PATH is set to "", which creates an error (See issue #44). Defaulting the variable to the local PS1 script, so it can be run locally as well as in SCM.