### PR TITLE
dotnet core preview2 preview3 support in kudu

### DIFF
--- a/lib/generator._js
+++ b/lib/generator._js
@@ -317,6 +317,9 @@ ScriptGenerator.prototype.generateAspNetCoreDeploymentScript = function (_) {
     // use dotnet command, not msbuild if NO solutionfile is provided
     // or if there's a solution file, but preview3 project
     var nugetOrDotnetRestore = this.projectPath.endsWith(".csproj") ? 'dotnet restore': nugetRestore;
+    if (this.solutionPath) {
+        nugetOrDotnetRestore += ' "'+ this.solutionPath +'"';
+    }
     this.generateAspNetCoreScript('aspnet.core.template', {aspNetCoreProject: this.projectPath, restore:nugetOrDotnetRestore}, _);
   }
 };

--- a/lib/generator.js
+++ b/lib/generator.js
@@ -317,11 +317,14 @@ ScriptGenerator.prototype.generateAspNetCoreDeploymentScript = function ScriptGe
 
 
         nugetOrDotnetRestore = (__this.projectPath.endsWith(".csproj") ? "dotnet restore" : nugetRestore);
-        return __this.generateAspNetCoreScript("aspnet.core.template", { aspNetCoreProject: __this.projectPath, restore: nugetOrDotnetRestore }, __cb(_, __frame, 47, 4, __then, true)); } ; })(_); });};
+        if (__this.solutionPath) {
+          nugetOrDotnetRestore += ((" \"" + __this.solutionPath) + "\""); } ;
+
+        return __this.generateAspNetCoreScript("aspnet.core.template", { aspNetCoreProject: __this.projectPath, restore: nugetOrDotnetRestore }, __cb(_, __frame, 50, 4, __then, true)); } ; })(_); });};
 
 
 
-ScriptGenerator.prototype.generateDnxConsoleAppDeploymentScript = function ScriptGenerator_prototype_generateDnxConsoleAppDeploymentScript__8(_) { var options, __this = this; var __frame = { name: "ScriptGenerator_prototype_generateDnxConsoleAppDeploymentScript__8", line: 324 }; return __func(_, this, arguments, ScriptGenerator_prototype_generateDnxConsoleAppDeploymentScript__8, 0, __frame, function __$ScriptGenerator_prototype_generateDnxConsoleAppDeploymentScript__8() {
+ScriptGenerator.prototype.generateDnxConsoleAppDeploymentScript = function ScriptGenerator_prototype_generateDnxConsoleAppDeploymentScript__8(_) { var options, __this = this; var __frame = { name: "ScriptGenerator_prototype_generateDnxConsoleAppDeploymentScript__8", line: 327 }; return __func(_, this, arguments, ScriptGenerator_prototype_generateDnxConsoleAppDeploymentScript__8, 0, __frame, function __$ScriptGenerator_prototype_generateDnxConsoleAppDeploymentScript__8() {
     if ((__this.scriptType != ScriptType.batch)) {
       return _(new Error("Only batch script files are supported for DNX Console Application")); } ;
 
@@ -335,7 +338,7 @@ ScriptGenerator.prototype.generateDnxConsoleAppDeploymentScript = function Scrip
     return __this.generateDnxConsoleAppScript("deploy.batch.dnx.consoleapp.template", options, __cb(_, __frame, 11, 2, _, true)); });};
 
 
-ScriptGenerator.prototype.generateDotNetConsoleDeploymentScript = function ScriptGenerator_prototype_generateDotNetConsoleDeploymentScript__9(_) { var msbuildArguments, solutionDir, solutionArgs, options, __this = this; var __frame = { name: "ScriptGenerator_prototype_generateDotNetConsoleDeploymentScript__9", line: 338 }; return __func(_, this, arguments, ScriptGenerator_prototype_generateDotNetConsoleDeploymentScript__9, 0, __frame, function __$ScriptGenerator_prototype_generateDotNetConsoleDeploymentScript__9() {
+ScriptGenerator.prototype.generateDotNetConsoleDeploymentScript = function ScriptGenerator_prototype_generateDotNetConsoleDeploymentScript__9(_) { var msbuildArguments, solutionDir, solutionArgs, options, __this = this; var __frame = { name: "ScriptGenerator_prototype_generateDotNetConsoleDeploymentScript__9", line: 341 }; return __func(_, this, arguments, ScriptGenerator_prototype_generateDotNetConsoleDeploymentScript__9, 0, __frame, function __$ScriptGenerator_prototype_generateDotNetConsoleDeploymentScript__9() {
     argNotNull(__this.projectPath, "projectPath");
 
     if (((__this.scriptType != ScriptType.batch) && (__this.scriptType != ScriptType.posh))) {
@@ -380,7 +383,7 @@ ScriptGenerator.prototype.generateDotNetConsoleDeploymentScript = function Scrip
     return __this.generateDotNetDeploymentScript("dotnetconsole.template", options, __cb(_, __frame, 42, 2, _, true)); });};
 
 
-ScriptGenerator.prototype.generateWebSiteDeploymentScript = function ScriptGenerator_prototype_generateWebSiteDeploymentScript__10(_) { var msbuildArguments, __this = this; var __frame = { name: "ScriptGenerator_prototype_generateWebSiteDeploymentScript__10", line: 383 }; return __func(_, this, arguments, ScriptGenerator_prototype_generateWebSiteDeploymentScript__10, 0, __frame, function __$ScriptGenerator_prototype_generateWebSiteDeploymentScript__10() { return (function __$ScriptGenerator_prototype_generateWebSiteDeploymentScript__10(__then) {
+ScriptGenerator.prototype.generateWebSiteDeploymentScript = function ScriptGenerator_prototype_generateWebSiteDeploymentScript__10(_) { var msbuildArguments, __this = this; var __frame = { name: "ScriptGenerator_prototype_generateWebSiteDeploymentScript__10", line: 386 }; return __func(_, this, arguments, ScriptGenerator_prototype_generateWebSiteDeploymentScript__10, 0, __frame, function __$ScriptGenerator_prototype_generateWebSiteDeploymentScript__10() { return (function __$ScriptGenerator_prototype_generateWebSiteDeploymentScript__10(__then) {
       if (__this.solutionPath) {
 
         log.info("Generating deployment script for .NET Web Site");
@@ -405,7 +408,7 @@ ScriptGenerator.prototype.generateWebSiteDeploymentScript = function ScriptGener
 
 
 
-ScriptGenerator.prototype.generateBasicDeploymentScript = function ScriptGenerator_prototype_generateBasicDeploymentScript__11(templateFileName, _) { var lowerCaseScriptType, fixedSitePath, templateContent, __this = this; var __frame = { name: "ScriptGenerator_prototype_generateBasicDeploymentScript__11", line: 408 }; return __func(_, this, arguments, ScriptGenerator_prototype_generateBasicDeploymentScript__11, 1, __frame, function __$ScriptGenerator_prototype_generateBasicDeploymentScript__11() {
+ScriptGenerator.prototype.generateBasicDeploymentScript = function ScriptGenerator_prototype_generateBasicDeploymentScript__11(templateFileName, _) { var lowerCaseScriptType, fixedSitePath, templateContent, __this = this; var __frame = { name: "ScriptGenerator_prototype_generateBasicDeploymentScript__11", line: 411 }; return __func(_, this, arguments, ScriptGenerator_prototype_generateBasicDeploymentScript__11, 1, __frame, function __$ScriptGenerator_prototype_generateBasicDeploymentScript__11() {
     argNotNull(templateFileName, "templateFileName");
 
     lowerCaseScriptType = __this.scriptType.toLowerCase();
@@ -419,7 +422,7 @@ ScriptGenerator.prototype.generateBasicDeploymentScript = function ScriptGenerat
     return __this.writeDeploymentFiles(templateContent, __cb(_, __frame, 11, 2, _, true)); });};
 
 
-ScriptGenerator.prototype.generateDotNetDeploymentScript = function ScriptGenerator_prototype_generateDotNetDeploymentScript__12(templateFileName, options, _) { var lowerCaseScriptType, solutionDir, templateContent, __this = this; var __frame = { name: "ScriptGenerator_prototype_generateDotNetDeploymentScript__12", line: 422 }; return __func(_, this, arguments, ScriptGenerator_prototype_generateDotNetDeploymentScript__12, 2, __frame, function __$ScriptGenerator_prototype_generateDotNetDeploymentScript__12() {
+ScriptGenerator.prototype.generateDotNetDeploymentScript = function ScriptGenerator_prototype_generateDotNetDeploymentScript__12(templateFileName, options, _) { var lowerCaseScriptType, solutionDir, templateContent, __this = this; var __frame = { name: "ScriptGenerator_prototype_generateDotNetDeploymentScript__12", line: 425 }; return __func(_, this, arguments, ScriptGenerator_prototype_generateDotNetDeploymentScript__12, 2, __frame, function __$ScriptGenerator_prototype_generateDotNetDeploymentScript__12() {
     argNotNull(templateFileName, "templateFileName");
 
 
@@ -439,7 +442,7 @@ ScriptGenerator.prototype.generateDotNetDeploymentScript = function ScriptGenera
     return __this.writeDeploymentFiles(templateContent, __cb(_, __frame, 17, 2, _, true)); });};
 
 
-ScriptGenerator.prototype.generateAspNetCoreScript = function ScriptGenerator_prototype_generateAspNetCoreScript__13(templateFileName, options, _) { var lowerCaseScriptType, templateContent, __this = this; var __frame = { name: "ScriptGenerator_prototype_generateAspNetCoreScript__13", line: 442 }; return __func(_, this, arguments, ScriptGenerator_prototype_generateAspNetCoreScript__13, 2, __frame, function __$ScriptGenerator_prototype_generateAspNetCoreScript__13() {
+ScriptGenerator.prototype.generateAspNetCoreScript = function ScriptGenerator_prototype_generateAspNetCoreScript__13(templateFileName, options, _) { var lowerCaseScriptType, templateContent, __this = this; var __frame = { name: "ScriptGenerator_prototype_generateAspNetCoreScript__13", line: 445 }; return __func(_, this, arguments, ScriptGenerator_prototype_generateAspNetCoreScript__13, 2, __frame, function __$ScriptGenerator_prototype_generateAspNetCoreScript__13() {
     argNotNull(templateFileName, "templateFileName");
 
     lowerCaseScriptType = __this.scriptType.toLowerCase();
@@ -485,7 +488,7 @@ function fixLineEndingsToWindows(contentStr) {
   return contentStr.replace(/(?:\r\n|\n)/g, "\r\n");};
 
 
-ScriptGenerator.prototype.writeDeploymentFiles = function ScriptGenerator_prototype_writeDeploymentFiles__14(templateContent, _) { var deployScriptFileName, deploymentCommand, deployScriptPath, deploymentFilePath, __this = this; var __frame = { name: "ScriptGenerator_prototype_writeDeploymentFiles__14", line: 488 }; return __func(_, this, arguments, ScriptGenerator_prototype_writeDeploymentFiles__14, 1, __frame, function __$ScriptGenerator_prototype_writeDeploymentFiles__14() {
+ScriptGenerator.prototype.writeDeploymentFiles = function ScriptGenerator_prototype_writeDeploymentFiles__14(templateContent, _) { var deployScriptFileName, deploymentCommand, deployScriptPath, deploymentFilePath, __this = this; var __frame = { name: "ScriptGenerator_prototype_writeDeploymentFiles__14", line: 491 }; return __func(_, this, arguments, ScriptGenerator_prototype_writeDeploymentFiles__14, 1, __frame, function __$ScriptGenerator_prototype_writeDeploymentFiles__14() {
     argNotNull(templateContent, "templateContent");
 
 
@@ -526,7 +529,7 @@ function getTemplatePath(fileName) {
   return path.join(templatesDir, fileName);};
 
 
-function writeContentToFile(path, content, _) { var __frame = { name: "writeContentToFile", line: 529 }; return __func(_, this, arguments, writeContentToFile, 2, __frame, function __$writeContentToFile() { return (function __$writeContentToFile(__then) {
+function writeContentToFile(path, content, _) { var __frame = { name: "writeContentToFile", line: 532 }; return __func(_, this, arguments, writeContentToFile, 2, __frame, function __$writeContentToFile() { return (function __$writeContentToFile(__then) {
 
       if (fs.existsSync(path)) {
         return confirm((("The file: \"" + path) + "\" already exists\nAre you sure you want to overwrite it (y/n): "), __cb(_, __frame, 3, 9, function ___(__0, __2) { var __1 = !__2; return (function __$writeContentToFile(__then) { if (__1) { return _(null); } else { __then(); } ; })(__then); }, true)); } else { __then(); } ; })(function __$writeContentToFile() {


### PR DESCRIPTION
Tested against the following 4 cases (with a link to the repo):
1. [preview1/2 VS](https://github.com/watashiSHUN/PREVIEW1sln)
this is a mixed project, we use `nuget3.5` to restore and `msbuild14` to build and `msbuild14` to publish(calling `dotnet publish`, which support "xproj")
2. [preview2 xplatform](https://github.com/watashiSHUN/PREVIEW2nsln)
similar to case 1, use `nuget3.5` to restore and `dotnet publish` for "xproj"
3. [preview3 VS](https://github.com/watashiSHUN/PREVIEW3sln)
preview3 dotnet project are using "csproj",  but we are not bringing `msbuild15` to antares yet, so we are using `dotnet restore` and `dotnet publish`
4. [preview3 xplatform](https://github.com/watashiSHUN/PREVIEW3nosln)
same as case 3, `dotnet restore` and `dotnet publish`