### PR TITLE
dotnet restore now works on project with libs

### DIFF
--- a/lib/generator._js
+++ b/lib/generator._js
@@ -330,7 +330,10 @@ ScriptGenerator.prototype.generateAspNetCoreDeploymentScript = function (_) {
     // or if there's a solution file, but preview3 project
     var nugetOrDotnetRestore = this.projectPath.endsWith(".csproj") ? 'dotnet restore': nugetRestore;
     if (this.solutionPath) {
-        nugetOrDotnetRestore += ' "'+ this.solutionPath +'"';
+        nugetOrDotnetRestore += ' "' + this.solutionPath + '"';
+    } else {
+        nugetOrDotnetRestore += ' "' + this.projectPath + '"';
+        // current directory does not have .sln or .csproj/.xproj, nuget restore will throw an error
     }
     this.generateAspNetCoreScript('aspnet.core.template', {aspNetCoreProject: this.projectPath, restore:nugetOrDotnetRestore}, _);
   }

--- a/lib/generator.js
+++ b/lib/generator.js
@@ -330,13 +330,16 @@ ScriptGenerator.prototype.generateAspNetCoreDeploymentScript = function ScriptGe
 
         nugetOrDotnetRestore = (__this.projectPath.endsWith(".csproj") ? "dotnet restore" : nugetRestore);
         if (__this.solutionPath) {
-          nugetOrDotnetRestore += ((" \"" + __this.solutionPath) + "\""); } ;
+          nugetOrDotnetRestore += ((" \"" + __this.solutionPath) + "\""); }
+         else {
+          nugetOrDotnetRestore += ((" \"" + __this.projectPath) + "\""); } ;
 
-        return __this.generateAspNetCoreScript("aspnet.core.template", { aspNetCoreProject: __this.projectPath, restore: nugetOrDotnetRestore }, __cb(_, __frame, 50, 4, __then, true)); } ; })(_); });};
+
+        return __this.generateAspNetCoreScript("aspnet.core.template", { aspNetCoreProject: __this.projectPath, restore: nugetOrDotnetRestore }, __cb(_, __frame, 53, 4, __then, true)); } ; })(_); });};
 
 
 
-ScriptGenerator.prototype.generateDnxConsoleAppDeploymentScript = function ScriptGenerator_prototype_generateDnxConsoleAppDeploymentScript__9(_) { var options, __this = this; var __frame = { name: "ScriptGenerator_prototype_generateDnxConsoleAppDeploymentScript__9", line: 339 }; return __func(_, this, arguments, ScriptGenerator_prototype_generateDnxConsoleAppDeploymentScript__9, 0, __frame, function __$ScriptGenerator_prototype_generateDnxConsoleAppDeploymentScript__9() {
+ScriptGenerator.prototype.generateDnxConsoleAppDeploymentScript = function ScriptGenerator_prototype_generateDnxConsoleAppDeploymentScript__9(_) { var options, __this = this; var __frame = { name: "ScriptGenerator_prototype_generateDnxConsoleAppDeploymentScript__9", line: 342 }; return __func(_, this, arguments, ScriptGenerator_prototype_generateDnxConsoleAppDeploymentScript__9, 0, __frame, function __$ScriptGenerator_prototype_generateDnxConsoleAppDeploymentScript__9() {
     if ((__this.scriptType != ScriptType.batch)) {
       return _(new Error("Only batch script files are supported for DNX Console Application")); } ;
 
@@ -350,7 +353,7 @@ ScriptGenerator.prototype.generateDnxConsoleAppDeploymentScript = function Scrip
     return __this.generateDnxConsoleAppScript("deploy.batch.dnx.consoleapp.template", options, __cb(_, __frame, 11, 2, _, true)); });};
 
 
-ScriptGenerator.prototype.generateDotNetConsoleDeploymentScript = function ScriptGenerator_prototype_generateDotNetConsoleDeploymentScript__10(_) { var msbuildArguments, solutionDir, solutionArgs, options, __this = this; var __frame = { name: "ScriptGenerator_prototype_generateDotNetConsoleDeploymentScript__10", line: 353 }; return __func(_, this, arguments, ScriptGenerator_prototype_generateDotNetConsoleDeploymentScript__10, 0, __frame, function __$ScriptGenerator_prototype_generateDotNetConsoleDeploymentScript__10() {
+ScriptGenerator.prototype.generateDotNetConsoleDeploymentScript = function ScriptGenerator_prototype_generateDotNetConsoleDeploymentScript__10(_) { var msbuildArguments, solutionDir, solutionArgs, options, __this = this; var __frame = { name: "ScriptGenerator_prototype_generateDotNetConsoleDeploymentScript__10", line: 356 }; return __func(_, this, arguments, ScriptGenerator_prototype_generateDotNetConsoleDeploymentScript__10, 0, __frame, function __$ScriptGenerator_prototype_generateDotNetConsoleDeploymentScript__10() {
     argNotNull(__this.projectPath, "projectPath");
 
     if (((__this.scriptType != ScriptType.batch) && (__this.scriptType != ScriptType.posh))) {
@@ -395,7 +398,7 @@ ScriptGenerator.prototype.generateDotNetConsoleDeploymentScript = function Scrip
     return __this.generateDotNetDeploymentScript("dotnetconsole.template", options, __cb(_, __frame, 42, 2, _, true)); });};
 
 
-ScriptGenerator.prototype.generateWebSiteDeploymentScript = function ScriptGenerator_prototype_generateWebSiteDeploymentScript__11(_) { var msbuildArguments, __this = this; var __frame = { name: "ScriptGenerator_prototype_generateWebSiteDeploymentScript__11", line: 398 }; return __func(_, this, arguments, ScriptGenerator_prototype_generateWebSiteDeploymentScript__11, 0, __frame, function __$ScriptGenerator_prototype_generateWebSiteDeploymentScript__11() { return (function __$ScriptGenerator_prototype_generateWebSiteDeploymentScript__11(__then) {
+ScriptGenerator.prototype.generateWebSiteDeploymentScript = function ScriptGenerator_prototype_generateWebSiteDeploymentScript__11(_) { var msbuildArguments, __this = this; var __frame = { name: "ScriptGenerator_prototype_generateWebSiteDeploymentScript__11", line: 401 }; return __func(_, this, arguments, ScriptGenerator_prototype_generateWebSiteDeploymentScript__11, 0, __frame, function __$ScriptGenerator_prototype_generateWebSiteDeploymentScript__11() { return (function __$ScriptGenerator_prototype_generateWebSiteDeploymentScript__11(__then) {
       if (__this.solutionPath) {
 
         log.info("Generating deployment script for .NET Web Site");
@@ -420,7 +423,7 @@ ScriptGenerator.prototype.generateWebSiteDeploymentScript = function ScriptGener
 
 
 
-ScriptGenerator.prototype.generateBasicDeploymentScript = function ScriptGenerator_prototype_generateBasicDeploymentScript__12(templateFileName, _) { var lowerCaseScriptType, fixedSitePath, templateContent, __this = this; var __frame = { name: "ScriptGenerator_prototype_generateBasicDeploymentScript__12", line: 423 }; return __func(_, this, arguments, ScriptGenerator_prototype_generateBasicDeploymentScript__12, 1, __frame, function __$ScriptGenerator_prototype_generateBasicDeploymentScript__12() {
+ScriptGenerator.prototype.generateBasicDeploymentScript = function ScriptGenerator_prototype_generateBasicDeploymentScript__12(templateFileName, _) { var lowerCaseScriptType, fixedSitePath, templateContent, __this = this; var __frame = { name: "ScriptGenerator_prototype_generateBasicDeploymentScript__12", line: 426 }; return __func(_, this, arguments, ScriptGenerator_prototype_generateBasicDeploymentScript__12, 1, __frame, function __$ScriptGenerator_prototype_generateBasicDeploymentScript__12() {
     argNotNull(templateFileName, "templateFileName");
 
     lowerCaseScriptType = __this.scriptType.toLowerCase();
@@ -434,7 +437,7 @@ ScriptGenerator.prototype.generateBasicDeploymentScript = function ScriptGenerat
     return __this.writeDeploymentFiles(templateContent, __cb(_, __frame, 11, 2, _, true)); });};
 
 
-ScriptGenerator.prototype.generateDotNetDeploymentScript = function ScriptGenerator_prototype_generateDotNetDeploymentScript__13(templateFileName, options, _) { var lowerCaseScriptType, solutionDir, templateContent, __this = this; var __frame = { name: "ScriptGenerator_prototype_generateDotNetDeploymentScript__13", line: 437 }; return __func(_, this, arguments, ScriptGenerator_prototype_generateDotNetDeploymentScript__13, 2, __frame, function __$ScriptGenerator_prototype_generateDotNetDeploymentScript__13() {
+ScriptGenerator.prototype.generateDotNetDeploymentScript = function ScriptGenerator_prototype_generateDotNetDeploymentScript__13(templateFileName, options, _) { var lowerCaseScriptType, solutionDir, templateContent, __this = this; var __frame = { name: "ScriptGenerator_prototype_generateDotNetDeploymentScript__13", line: 440 }; return __func(_, this, arguments, ScriptGenerator_prototype_generateDotNetDeploymentScript__13, 2, __frame, function __$ScriptGenerator_prototype_generateDotNetDeploymentScript__13() {
     argNotNull(templateFileName, "templateFileName");
 
 
@@ -454,7 +457,7 @@ ScriptGenerator.prototype.generateDotNetDeploymentScript = function ScriptGenera
     return __this.writeDeploymentFiles(templateContent, __cb(_, __frame, 17, 2, _, true)); });};
 
 
-ScriptGenerator.prototype.generateAspNetCoreScript = function ScriptGenerator_prototype_generateAspNetCoreScript__14(templateFileName, options, _) { var lowerCaseScriptType, templateContent, __this = this; var __frame = { name: "ScriptGenerator_prototype_generateAspNetCoreScript__14", line: 457 }; return __func(_, this, arguments, ScriptGenerator_prototype_generateAspNetCoreScript__14, 2, __frame, function __$ScriptGenerator_prototype_generateAspNetCoreScript__14() {
+ScriptGenerator.prototype.generateAspNetCoreScript = function ScriptGenerator_prototype_generateAspNetCoreScript__14(templateFileName, options, _) { var lowerCaseScriptType, templateContent, __this = this; var __frame = { name: "ScriptGenerator_prototype_generateAspNetCoreScript__14", line: 460 }; return __func(_, this, arguments, ScriptGenerator_prototype_generateAspNetCoreScript__14, 2, __frame, function __$ScriptGenerator_prototype_generateAspNetCoreScript__14() {
     argNotNull(templateFileName, "templateFileName");
 
     lowerCaseScriptType = __this.scriptType.toLowerCase();
@@ -500,7 +503,7 @@ function fixLineEndingsToWindows(contentStr) {
   return contentStr.replace(/(?:\r\n|\n)/g, "\r\n");};
 
 
-ScriptGenerator.prototype.writeDeploymentFiles = function ScriptGenerator_prototype_writeDeploymentFiles__15(templateContent, _) { var deployScriptFileName, deploymentCommand, deployScriptPath, deploymentFilePath, __this = this; var __frame = { name: "ScriptGenerator_prototype_writeDeploymentFiles__15", line: 503 }; return __func(_, this, arguments, ScriptGenerator_prototype_writeDeploymentFiles__15, 1, __frame, function __$ScriptGenerator_prototype_writeDeploymentFiles__15() {
+ScriptGenerator.prototype.writeDeploymentFiles = function ScriptGenerator_prototype_writeDeploymentFiles__15(templateContent, _) { var deployScriptFileName, deploymentCommand, deployScriptPath, deploymentFilePath, __this = this; var __frame = { name: "ScriptGenerator_prototype_writeDeploymentFiles__15", line: 506 }; return __func(_, this, arguments, ScriptGenerator_prototype_writeDeploymentFiles__15, 1, __frame, function __$ScriptGenerator_prototype_writeDeploymentFiles__15() {
     argNotNull(templateContent, "templateContent");
 
 
@@ -541,7 +544,7 @@ function getTemplatePath(fileName) {
   return path.join(templatesDir, fileName);};
 
 
-function writeContentToFile(path, content, _) { var __frame = { name: "writeContentToFile", line: 544 }; return __func(_, this, arguments, writeContentToFile, 2, __frame, function __$writeContentToFile() { return (function __$writeContentToFile(__then) {
+function writeContentToFile(path, content, _) { var __frame = { name: "writeContentToFile", line: 547 }; return __func(_, this, arguments, writeContentToFile, 2, __frame, function __$writeContentToFile() { return (function __$writeContentToFile(__then) {
 
       if (fs.existsSync(path)) {
         return confirm((("The file: \"" + path) + "\" already exists\nAre you sure you want to overwrite it (y/n): "), __cb(_, __frame, 3, 9, function ___(__0, __2) { var __1 = !__2; return (function __$writeContentToFile(__then) { if (__1) { return _(null); } else { __then(); } ; })(__then); }, true)); } else { __then(); } ; })(function __$writeContentToFile() {


### PR DESCRIPTION
it looks like we don't really deal with (project created by `dotnet cli` + manually added `libraries`).
[old dotnet core template ](https://github.com/projectkudu/KuduScript/commit/2da355d8e9ae1b7c65f9cc0db42b1f038ba9b083#diff-6cf65683ddeb01b07b91519845012536) does not take argument after `nuget restore`

but restoring package will fail for this perfectly valid dotnet core project ([repository](https://github.com/watashiSHUN/dotnetcoreRC3cli))

so I now pass the ".csproj/.xproj" (the project being deployed ) to nuget restore.