### PR TITLE
Add php deployment support

### DIFF
--- a/bin/kuduscript.js
+++ b/bin/kuduscript.js
@@ -76,6 +76,8 @@ function deploymentScriptExecute(name, options, log, confirm, _) {
     projectType = generator.ProjectType.functionApp;
   } else if (options.ruby) {
     projectType = generator.ProjectType.ruby;
+  } else if (options.php) {
+    projectType = generator.ProjectType.php;
   } else {
     projectType = generator.ProjectType.basic;
   }

--- a/lib/generator._js
+++ b/lib/generator._js
@@ -45,6 +45,7 @@ var ProjectType = {
   aspNetCore: 'ASP_NET_CORE',
   go: 'GO',
   ruby: "RUBY",
+  php: "PHP"
 };
 
 exports.ScriptType = ScriptType;
@@ -129,6 +130,7 @@ function ScriptGenerator(repositoryRoot, projectType, projectPath, solutionPath,
   this.generators[ProjectType.aspNetCore] = generateAspNetCoreDeploymentScript;
   this.generators[ProjectType.go] = generateGoDeploymentScript;
   this.generators[ProjectType.ruby] = generateRubyDeploymentScript;
+  this.generators[ProjectType.php] = generatePHPDeploymentScript;
 }
 
 function generateGoDeploymentScript(scriptGenerator, _) {
@@ -165,6 +167,10 @@ function generatePythonDeploymentScript(scriptGenerator, _) {
 
 function generateRubyDeploymentScript(scriptGenerator, _) {
   scriptGenerator.generateRubyDeploymentScript(_);
+}
+
+function generatePHPDeploymentScript(scriptGenerator, _) {
+  scriptGenerator.generatePHPDeploymentScript(_);
 }
 
 function generateBasicWebSiteDeploymentScript(scriptGenerator, _) {
@@ -229,6 +235,12 @@ ScriptGenerator.prototype.generateRubyDeploymentScript = function (_) {
   log.info('Generating deployment script for Ruby Web Site');
 
   this.generateBasicDeploymentScript('ruby.template', _);
+};
+
+ScriptGenerator.prototype.generatePHPDeploymentScript = function (_) {
+  log.info('Generating deployment script for PHP Web Site');
+
+  this.generateBasicDeploymentScript('php.template', _);
 };
 
 ScriptGenerator.prototype.generateWapDeploymentScript = function (_) {

--- a/lib/generator.js
+++ b/lib/generator.js
@@ -44,7 +44,8 @@ var ProjectType = {
   dotNetConsole: "DOT_NET_CONSOLE",
   aspNetCore: "ASP_NET_CORE",
   go: "GO",
-  ruby: "RUBY"};
+  ruby: "RUBY",
+  php: "PHP"};
 
 
 exports.ScriptType = ScriptType;
@@ -128,57 +129,62 @@ function ScriptGenerator(repositoryRoot, projectType, projectPath, solutionPath,
   this.generators[ProjectType.dotNetConsole] = generateDotNetConsoleDeploymentScript;
   this.generators[ProjectType.aspNetCore] = generateAspNetCoreDeploymentScript;
   this.generators[ProjectType.go] = generateGoDeploymentScript;
-  this.generators[ProjectType.ruby] = generateRubyDeploymentScript;};
+  this.generators[ProjectType.ruby] = generateRubyDeploymentScript;
+  this.generators[ProjectType.php] = generatePHPDeploymentScript;};
 
 
-function generateGoDeploymentScript(scriptGenerator, _) { var __frame = { name: "generateGoDeploymentScript", line: 134 }; return __func(_, this, arguments, generateGoDeploymentScript, 1, __frame, function __$generateGoDeploymentScript() {
+function generateGoDeploymentScript(scriptGenerator, _) { var __frame = { name: "generateGoDeploymentScript", line: 136 }; return __func(_, this, arguments, generateGoDeploymentScript, 1, __frame, function __$generateGoDeploymentScript() {
     return scriptGenerator.generateGoDeploymentScript(__cb(_, __frame, 1, 2, _, true)); });};
 
 
-function generateAspNetCoreDeploymentScript(scriptGenerator, _) { var __frame = { name: "generateAspNetCoreDeploymentScript", line: 138 }; return __func(_, this, arguments, generateAspNetCoreDeploymentScript, 1, __frame, function __$generateAspNetCoreDeploymentScript() {
+function generateAspNetCoreDeploymentScript(scriptGenerator, _) { var __frame = { name: "generateAspNetCoreDeploymentScript", line: 140 }; return __func(_, this, arguments, generateAspNetCoreDeploymentScript, 1, __frame, function __$generateAspNetCoreDeploymentScript() {
     return scriptGenerator.generateAspNetCoreDeploymentScript(__cb(_, __frame, 1, 2, _, true)); });};
 
 
-function generateDnxConsoleAppDeploymentScript(scriptGenerator, _) { var __frame = { name: "generateDnxConsoleAppDeploymentScript", line: 142 }; return __func(_, this, arguments, generateDnxConsoleAppDeploymentScript, 1, __frame, function __$generateDnxConsoleAppDeploymentScript() {
+function generateDnxConsoleAppDeploymentScript(scriptGenerator, _) { var __frame = { name: "generateDnxConsoleAppDeploymentScript", line: 144 }; return __func(_, this, arguments, generateDnxConsoleAppDeploymentScript, 1, __frame, function __$generateDnxConsoleAppDeploymentScript() {
     return scriptGenerator.generateDnxConsoleAppDeploymentScript(__cb(_, __frame, 1, 2, _, true)); });};
 
 
-function generateDotNetConsoleDeploymentScript(scriptGenerator, _) { var __frame = { name: "generateDotNetConsoleDeploymentScript", line: 146 }; return __func(_, this, arguments, generateDotNetConsoleDeploymentScript, 1, __frame, function __$generateDotNetConsoleDeploymentScript() {
+function generateDotNetConsoleDeploymentScript(scriptGenerator, _) { var __frame = { name: "generateDotNetConsoleDeploymentScript", line: 148 }; return __func(_, this, arguments, generateDotNetConsoleDeploymentScript, 1, __frame, function __$generateDotNetConsoleDeploymentScript() {
     return scriptGenerator.generateDotNetConsoleDeploymentScript(__cb(_, __frame, 1, 2, _, true)); });};
 
 
-function generateWapDeploymentScript(scriptGenerator, _) { var __frame = { name: "generateWapDeploymentScript", line: 150 }; return __func(_, this, arguments, generateWapDeploymentScript, 1, __frame, function __$generateWapDeploymentScript() {
+function generateWapDeploymentScript(scriptGenerator, _) { var __frame = { name: "generateWapDeploymentScript", line: 152 }; return __func(_, this, arguments, generateWapDeploymentScript, 1, __frame, function __$generateWapDeploymentScript() {
     return scriptGenerator.generateWapDeploymentScript(__cb(_, __frame, 1, 2, _, true)); });};
 
 
-function generateWebSiteDeploymentScript(scriptGenerator, _) { var __frame = { name: "generateWebSiteDeploymentScript", line: 154 }; return __func(_, this, arguments, generateWebSiteDeploymentScript, 1, __frame, function __$generateWebSiteDeploymentScript() {
+function generateWebSiteDeploymentScript(scriptGenerator, _) { var __frame = { name: "generateWebSiteDeploymentScript", line: 156 }; return __func(_, this, arguments, generateWebSiteDeploymentScript, 1, __frame, function __$generateWebSiteDeploymentScript() {
     return scriptGenerator.generateWebSiteDeploymentScript(__cb(_, __frame, 1, 2, _, true)); });};
 
 
-function generateNodeDeploymentScript(scriptGenerator, _) { var __frame = { name: "generateNodeDeploymentScript", line: 158 }; return __func(_, this, arguments, generateNodeDeploymentScript, 1, __frame, function __$generateNodeDeploymentScript() {
+function generateNodeDeploymentScript(scriptGenerator, _) { var __frame = { name: "generateNodeDeploymentScript", line: 160 }; return __func(_, this, arguments, generateNodeDeploymentScript, 1, __frame, function __$generateNodeDeploymentScript() {
     return scriptGenerator.generateNodeDeploymentScript(__cb(_, __frame, 1, 2, _, true)); });};
 
 
-function generatePythonDeploymentScript(scriptGenerator, _) { var __frame = { name: "generatePythonDeploymentScript", line: 162 }; return __func(_, this, arguments, generatePythonDeploymentScript, 1, __frame, function __$generatePythonDeploymentScript() {
+function generatePythonDeploymentScript(scriptGenerator, _) { var __frame = { name: "generatePythonDeploymentScript", line: 164 }; return __func(_, this, arguments, generatePythonDeploymentScript, 1, __frame, function __$generatePythonDeploymentScript() {
     return scriptGenerator.generatePythonDeploymentScript(__cb(_, __frame, 1, 2, _, true)); });};
 
 
-function generateRubyDeploymentScript(scriptGenerator, _) { var __frame = { name: "generateRubyDeploymentScript", line: 166 }; return __func(_, this, arguments, generateRubyDeploymentScript, 1, __frame, function __$generateRubyDeploymentScript() {
+function generateRubyDeploymentScript(scriptGenerator, _) { var __frame = { name: "generateRubyDeploymentScript", line: 168 }; return __func(_, this, arguments, generateRubyDeploymentScript, 1, __frame, function __$generateRubyDeploymentScript() {
     return scriptGenerator.generateRubyDeploymentScript(__cb(_, __frame, 1, 2, _, true)); });};
 
 
-function generateBasicWebSiteDeploymentScript(scriptGenerator, _) { var __frame = { name: "generateBasicWebSiteDeploymentScript", line: 170 }; return __func(_, this, arguments, generateBasicWebSiteDeploymentScript, 1, __frame, function __$generateBasicWebSiteDeploymentScript() {
+function generatePHPDeploymentScript(scriptGenerator, _) { var __frame = { name: "generatePHPDeploymentScript", line: 172 }; return __func(_, this, arguments, generatePHPDeploymentScript, 1, __frame, function __$generatePHPDeploymentScript() {
+    return scriptGenerator.generatePHPDeploymentScript(__cb(_, __frame, 1, 2, _, true)); });};
+
+
+function generateBasicWebSiteDeploymentScript(scriptGenerator, _) { var __frame = { name: "generateBasicWebSiteDeploymentScript", line: 176 }; return __func(_, this, arguments, generateBasicWebSiteDeploymentScript, 1, __frame, function __$generateBasicWebSiteDeploymentScript() {
     if (scriptGenerator.solutionPath) {
       return _(new Error("Solution path is not supported with this website type")); } ;
 
     return scriptGenerator.generateWebSiteDeploymentScript(__cb(_, __frame, 4, 2, _, true)); });};
 
 
-function generateFunctionAppDeploymentScript(scriptGenerator, _) { var __frame = { name: "generateFunctionAppDeploymentScript", line: 177 }; return __func(_, this, arguments, generateFunctionAppDeploymentScript, 1, __frame, function __$generateFunctionAppDeploymentScript() {
+function generateFunctionAppDeploymentScript(scriptGenerator, _) { var __frame = { name: "generateFunctionAppDeploymentScript", line: 183 }; return __func(_, this, arguments, generateFunctionAppDeploymentScript, 1, __frame, function __$generateFunctionAppDeploymentScript() {
     return scriptGenerator.generateFunctionAppDeploymentScript(__cb(_, __frame, 1, 4, _, true)); });};
 
 
-ScriptGenerator.prototype.generateDeploymentScript = function ScriptGenerator_prototype_generateDeploymentScript__1(_) { var generator, __this = this; var __frame = { name: "ScriptGenerator_prototype_generateDeploymentScript__1", line: 181 }; return __func(_, this, arguments, ScriptGenerator_prototype_generateDeploymentScript__1, 0, __frame, function __$ScriptGenerator_prototype_generateDeploymentScript__1() {
+ScriptGenerator.prototype.generateDeploymentScript = function ScriptGenerator_prototype_generateDeploymentScript__1(_) { var generator, __this = this; var __frame = { name: "ScriptGenerator_prototype_generateDeploymentScript__1", line: 187 }; return __func(_, this, arguments, ScriptGenerator_prototype_generateDeploymentScript__1, 0, __frame, function __$ScriptGenerator_prototype_generateDeploymentScript__1() {
     generator = __this.generators[__this.projectType];
     if (!generator) {
       return _(new Error(("Invalid project type received: " + __this.projectType))); } ;
@@ -197,25 +203,25 @@ function isPathSubDir(parentPath, childPath) {
 
 
 
-ScriptGenerator.prototype.generateGoDeploymentScript = function ScriptGenerator_prototype_generateGoDeploymentScript__2(_) { var __this = this; var __frame = { name: "ScriptGenerator_prototype_generateGoDeploymentScript__2", line: 200 }; return __func(_, this, arguments, ScriptGenerator_prototype_generateGoDeploymentScript__2, 0, __frame, function __$ScriptGenerator_prototype_generateGoDeploymentScript__2() {
+ScriptGenerator.prototype.generateGoDeploymentScript = function ScriptGenerator_prototype_generateGoDeploymentScript__2(_) { var __this = this; var __frame = { name: "ScriptGenerator_prototype_generateGoDeploymentScript__2", line: 206 }; return __func(_, this, arguments, ScriptGenerator_prototype_generateGoDeploymentScript__2, 0, __frame, function __$ScriptGenerator_prototype_generateGoDeploymentScript__2() {
     log.info("Generating deployment script for Go Web Site");
 
     return __this.generateBasicDeploymentScript("go.template", __cb(_, __frame, 3, 2, _, true)); });};
 
 
-ScriptGenerator.prototype.generateNodeDeploymentScript = function ScriptGenerator_prototype_generateNodeDeploymentScript__3(_) { var __this = this; var __frame = { name: "ScriptGenerator_prototype_generateNodeDeploymentScript__3", line: 206 }; return __func(_, this, arguments, ScriptGenerator_prototype_generateNodeDeploymentScript__3, 0, __frame, function __$ScriptGenerator_prototype_generateNodeDeploymentScript__3() {
+ScriptGenerator.prototype.generateNodeDeploymentScript = function ScriptGenerator_prototype_generateNodeDeploymentScript__3(_) { var __this = this; var __frame = { name: "ScriptGenerator_prototype_generateNodeDeploymentScript__3", line: 212 }; return __func(_, this, arguments, ScriptGenerator_prototype_generateNodeDeploymentScript__3, 0, __frame, function __$ScriptGenerator_prototype_generateNodeDeploymentScript__3() {
     log.info("Generating deployment script for node.js Web Site");
 
     return __this.generateBasicDeploymentScript("node.template", __cb(_, __frame, 3, 2, _, true)); });};
 
 
-ScriptGenerator.prototype.generateFunctionAppDeploymentScript = function ScriptGenerator_prototype_generateFunctionAppDeploymentScript__4(_) { var __this = this; var __frame = { name: "ScriptGenerator_prototype_generateFunctionAppDeploymentScript__4", line: 212 }; return __func(_, this, arguments, ScriptGenerator_prototype_generateFunctionAppDeploymentScript__4, 0, __frame, function __$ScriptGenerator_prototype_generateFunctionAppDeploymentScript__4() {
+ScriptGenerator.prototype.generateFunctionAppDeploymentScript = function ScriptGenerator_prototype_generateFunctionAppDeploymentScript__4(_) { var __this = this; var __frame = { name: "ScriptGenerator_prototype_generateFunctionAppDeploymentScript__4", line: 218 }; return __func(_, this, arguments, ScriptGenerator_prototype_generateFunctionAppDeploymentScript__4, 0, __frame, function __$ScriptGenerator_prototype_generateFunctionAppDeploymentScript__4() {
     log.info("Generating deployment script for function App");
 
     return __this.generateBasicDeploymentScript("functionApp.template", __cb(_, __frame, 3, 4, _, true)); });};
 
 
-ScriptGenerator.prototype.generatePythonDeploymentScript = function ScriptGenerator_prototype_generatePythonDeploymentScript__5(_) { var __this = this; var __frame = { name: "ScriptGenerator_prototype_generatePythonDeploymentScript__5", line: 218 }; return __func(_, this, arguments, ScriptGenerator_prototype_generatePythonDeploymentScript__5, 0, __frame, function __$ScriptGenerator_prototype_generatePythonDeploymentScript__5() {
+ScriptGenerator.prototype.generatePythonDeploymentScript = function ScriptGenerator_prototype_generatePythonDeploymentScript__5(_) { var __this = this; var __frame = { name: "ScriptGenerator_prototype_generatePythonDeploymentScript__5", line: 224 }; return __func(_, this, arguments, ScriptGenerator_prototype_generatePythonDeploymentScript__5, 0, __frame, function __$ScriptGenerator_prototype_generatePythonDeploymentScript__5() {
     log.info("Generating deployment script for python Web Site");
 
     if ((__this.scriptType != ScriptType.batch)) {
@@ -225,13 +231,19 @@ ScriptGenerator.prototype.generatePythonDeploymentScript = function ScriptGenera
     return __this.generateBasicDeploymentScript("python.template", __cb(_, __frame, 7, 2, _, true)); });};
 
 
-ScriptGenerator.prototype.generateRubyDeploymentScript = function ScriptGenerator_prototype_generateRubyDeploymentScript__6(_) { var __this = this; var __frame = { name: "ScriptGenerator_prototype_generateRubyDeploymentScript__6", line: 228 }; return __func(_, this, arguments, ScriptGenerator_prototype_generateRubyDeploymentScript__6, 0, __frame, function __$ScriptGenerator_prototype_generateRubyDeploymentScript__6() {
+ScriptGenerator.prototype.generateRubyDeploymentScript = function ScriptGenerator_prototype_generateRubyDeploymentScript__6(_) { var __this = this; var __frame = { name: "ScriptGenerator_prototype_generateRubyDeploymentScript__6", line: 234 }; return __func(_, this, arguments, ScriptGenerator_prototype_generateRubyDeploymentScript__6, 0, __frame, function __$ScriptGenerator_prototype_generateRubyDeploymentScript__6() {
     log.info("Generating deployment script for Ruby Web Site");
 
     return __this.generateBasicDeploymentScript("ruby.template", __cb(_, __frame, 3, 2, _, true)); });};
 
 
-ScriptGenerator.prototype.generateWapDeploymentScript = function ScriptGenerator_prototype_generateWapDeploymentScript__7(_) { var msbuildArguments, msbuildArgumentsForInPlace, solutionDir, solutionArgs, options, __this = this; var __frame = { name: "ScriptGenerator_prototype_generateWapDeploymentScript__7", line: 234 }; return __func(_, this, arguments, ScriptGenerator_prototype_generateWapDeploymentScript__7, 0, __frame, function __$ScriptGenerator_prototype_generateWapDeploymentScript__7() {
+ScriptGenerator.prototype.generatePHPDeploymentScript = function ScriptGenerator_prototype_generatePHPDeploymentScript__7(_) { var __this = this; var __frame = { name: "ScriptGenerator_prototype_generatePHPDeploymentScript__7", line: 240 }; return __func(_, this, arguments, ScriptGenerator_prototype_generatePHPDeploymentScript__7, 0, __frame, function __$ScriptGenerator_prototype_generatePHPDeploymentScript__7() {
+    log.info("Generating deployment script for PHP Web Site");
+
+    return __this.generateBasicDeploymentScript("php.template", __cb(_, __frame, 3, 2, _, true)); });};
+
+
+ScriptGenerator.prototype.generateWapDeploymentScript = function ScriptGenerator_prototype_generateWapDeploymentScript__8(_) { var msbuildArguments, msbuildArgumentsForInPlace, solutionDir, solutionArgs, options, __this = this; var __frame = { name: "ScriptGenerator_prototype_generateWapDeploymentScript__8", line: 246 }; return __func(_, this, arguments, ScriptGenerator_prototype_generateWapDeploymentScript__8, 0, __frame, function __$ScriptGenerator_prototype_generateWapDeploymentScript__8() {
     argNotNull(__this.projectPath, "projectPath");
 
     if (((__this.scriptType != ScriptType.batch) && (__this.scriptType != ScriptType.posh))) {
@@ -282,11 +294,11 @@ ScriptGenerator.prototype.generateWapDeploymentScript = function ScriptGenerator
     return __this.generateDotNetDeploymentScript("aspnet.wap.template", options, __cb(_, __frame, 48, 2, _, true)); });};
 
 
-ScriptGenerator.prototype.generateAspNetCoreDeploymentScript = function ScriptGenerator_prototype_generateAspNetCoreDeploymentScript__8(_) { var nuget_35_renamed, nugetRestore, files, webProjFiles, msbuildArguments, dotnetpublishArguments, options, nugetOrDotnetRestore, __this = this; var __frame = { name: "ScriptGenerator_prototype_generateAspNetCoreDeploymentScript__8", line: 285 }; return __func(_, this, arguments, ScriptGenerator_prototype_generateAspNetCoreDeploymentScript__8, 0, __frame, function __$ScriptGenerator_prototype_generateAspNetCoreDeploymentScript__8() {
+ScriptGenerator.prototype.generateAspNetCoreDeploymentScript = function ScriptGenerator_prototype_generateAspNetCoreDeploymentScript__9(_) { var nuget_35_renamed, nugetRestore, files, webProjFiles, msbuildArguments, dotnetpublishArguments, options, nugetOrDotnetRestore, __this = this; var __frame = { name: "ScriptGenerator_prototype_generateAspNetCoreDeploymentScript__9", line: 297 }; return __func(_, this, arguments, ScriptGenerator_prototype_generateAspNetCoreDeploymentScript__9, 0, __frame, function __$ScriptGenerator_prototype_generateAspNetCoreDeploymentScript__9() {
     argNotNull(__this.absoluteProjectPath, "absoluteProjectPath");
 
     nuget_35_renamed = "nuget.exe";
-    nugetRestore = (nuget_35_renamed + " restore -packagesavemode nuspec"); return (function __$ScriptGenerator_prototype_generateAspNetCoreDeploymentScript__8(__then) {
+    nugetRestore = (nuget_35_renamed + " restore -packagesavemode nuspec"); return (function __$ScriptGenerator_prototype_generateAspNetCoreDeploymentScript__9(__then) {
 
       if ((__this.solutionPath && !(__this.projectPath.endsWith(".csproj")))) {
 
@@ -335,7 +347,7 @@ ScriptGenerator.prototype.generateAspNetCoreDeploymentScript = function ScriptGe
 
 
 
-ScriptGenerator.prototype.generateDnxConsoleAppDeploymentScript = function ScriptGenerator_prototype_generateDnxConsoleAppDeploymentScript__9(_) { var options, __this = this; var __frame = { name: "ScriptGenerator_prototype_generateDnxConsoleAppDeploymentScript__9", line: 338 }; return __func(_, this, arguments, ScriptGenerator_prototype_generateDnxConsoleAppDeploymentScript__9, 0, __frame, function __$ScriptGenerator_prototype_generateDnxConsoleAppDeploymentScript__9() {
+ScriptGenerator.prototype.generateDnxConsoleAppDeploymentScript = function ScriptGenerator_prototype_generateDnxConsoleAppDeploymentScript__10(_) { var options, __this = this; var __frame = { name: "ScriptGenerator_prototype_generateDnxConsoleAppDeploymentScript__10", line: 350 }; return __func(_, this, arguments, ScriptGenerator_prototype_generateDnxConsoleAppDeploymentScript__10, 0, __frame, function __$ScriptGenerator_prototype_generateDnxConsoleAppDeploymentScript__10() {
     if ((__this.scriptType != ScriptType.batch)) {
       return _(new Error("Only batch script files are supported for DNX Console Application")); } ;
 
@@ -349,7 +361,7 @@ ScriptGenerator.prototype.generateDnxConsoleAppDeploymentScript = function Scrip
     return __this.generateDnxConsoleAppScript("deploy.batch.dnx.consoleapp.template", options, __cb(_, __frame, 11, 2, _, true)); });};
 
 
-ScriptGenerator.prototype.generateDotNetConsoleDeploymentScript = function ScriptGenerator_prototype_generateDotNetConsoleDeploymentScript__10(_) { var msbuildArguments, solutionDir, solutionArgs, options, __this = this; var __frame = { name: "ScriptGenerator_prototype_generateDotNetConsoleDeploymentScript__10", line: 352 }; return __func(_, this, arguments, ScriptGenerator_prototype_generateDotNetConsoleDeploymentScript__10, 0, __frame, function __$ScriptGenerator_prototype_generateDotNetConsoleDeploymentScript__10() {
+ScriptGenerator.prototype.generateDotNetConsoleDeploymentScript = function ScriptGenerator_prototype_generateDotNetConsoleDeploymentScript__11(_) { var msbuildArguments, solutionDir, solutionArgs, options, __this = this; var __frame = { name: "ScriptGenerator_prototype_generateDotNetConsoleDeploymentScript__11", line: 364 }; return __func(_, this, arguments, ScriptGenerator_prototype_generateDotNetConsoleDeploymentScript__11, 0, __frame, function __$ScriptGenerator_prototype_generateDotNetConsoleDeploymentScript__11() {
     argNotNull(__this.projectPath, "projectPath");
 
     if (((__this.scriptType != ScriptType.batch) && (__this.scriptType != ScriptType.posh))) {
@@ -394,7 +406,7 @@ ScriptGenerator.prototype.generateDotNetConsoleDeploymentScript = function Scrip
     return __this.generateDotNetDeploymentScript("dotnetconsole.template", options, __cb(_, __frame, 42, 2, _, true)); });};
 
 
-ScriptGenerator.prototype.generateWebSiteDeploymentScript = function ScriptGenerator_prototype_generateWebSiteDeploymentScript__11(_) { var msbuildArguments, __this = this; var __frame = { name: "ScriptGenerator_prototype_generateWebSiteDeploymentScript__11", line: 397 }; return __func(_, this, arguments, ScriptGenerator_prototype_generateWebSiteDeploymentScript__11, 0, __frame, function __$ScriptGenerator_prototype_generateWebSiteDeploymentScript__11() { return (function __$ScriptGenerator_prototype_generateWebSiteDeploymentScript__11(__then) {
+ScriptGenerator.prototype.generateWebSiteDeploymentScript = function ScriptGenerator_prototype_generateWebSiteDeploymentScript__12(_) { var msbuildArguments, __this = this; var __frame = { name: "ScriptGenerator_prototype_generateWebSiteDeploymentScript__12", line: 409 }; return __func(_, this, arguments, ScriptGenerator_prototype_generateWebSiteDeploymentScript__12, 0, __frame, function __$ScriptGenerator_prototype_generateWebSiteDeploymentScript__12() { return (function __$ScriptGenerator_prototype_generateWebSiteDeploymentScript__12(__then) {
       if (__this.solutionPath) {
 
         log.info("Generating deployment script for .NET Web Site");
@@ -419,7 +431,7 @@ ScriptGenerator.prototype.generateWebSiteDeploymentScript = function ScriptGener
 
 
 
-ScriptGenerator.prototype.generateBasicDeploymentScript = function ScriptGenerator_prototype_generateBasicDeploymentScript__12(templateFileName, _) { var lowerCaseScriptType, fixedSitePath, templateContent, __this = this; var __frame = { name: "ScriptGenerator_prototype_generateBasicDeploymentScript__12", line: 422 }; return __func(_, this, arguments, ScriptGenerator_prototype_generateBasicDeploymentScript__12, 1, __frame, function __$ScriptGenerator_prototype_generateBasicDeploymentScript__12() {
+ScriptGenerator.prototype.generateBasicDeploymentScript = function ScriptGenerator_prototype_generateBasicDeploymentScript__13(templateFileName, _) { var lowerCaseScriptType, fixedSitePath, templateContent, __this = this; var __frame = { name: "ScriptGenerator_prototype_generateBasicDeploymentScript__13", line: 434 }; return __func(_, this, arguments, ScriptGenerator_prototype_generateBasicDeploymentScript__13, 1, __frame, function __$ScriptGenerator_prototype_generateBasicDeploymentScript__13() {
     argNotNull(templateFileName, "templateFileName");
 
     lowerCaseScriptType = __this.scriptType.toLowerCase();
@@ -433,7 +445,7 @@ ScriptGenerator.prototype.generateBasicDeploymentScript = function ScriptGenerat
     return __this.writeDeploymentFiles(templateContent, __cb(_, __frame, 11, 2, _, true)); });};
 
 
-ScriptGenerator.prototype.generateDotNetDeploymentScript = function ScriptGenerator_prototype_generateDotNetDeploymentScript__13(templateFileName, options, _) { var lowerCaseScriptType, solutionDir, templateContent, __this = this; var __frame = { name: "ScriptGenerator_prototype_generateDotNetDeploymentScript__13", line: 436 }; return __func(_, this, arguments, ScriptGenerator_prototype_generateDotNetDeploymentScript__13, 2, __frame, function __$ScriptGenerator_prototype_generateDotNetDeploymentScript__13() {
+ScriptGenerator.prototype.generateDotNetDeploymentScript = function ScriptGenerator_prototype_generateDotNetDeploymentScript__14(templateFileName, options, _) { var lowerCaseScriptType, solutionDir, templateContent, __this = this; var __frame = { name: "ScriptGenerator_prototype_generateDotNetDeploymentScript__14", line: 448 }; return __func(_, this, arguments, ScriptGenerator_prototype_generateDotNetDeploymentScript__14, 2, __frame, function __$ScriptGenerator_prototype_generateDotNetDeploymentScript__14() {
     argNotNull(templateFileName, "templateFileName");
 
 
@@ -453,7 +465,7 @@ ScriptGenerator.prototype.generateDotNetDeploymentScript = function ScriptGenera
     return __this.writeDeploymentFiles(templateContent, __cb(_, __frame, 17, 2, _, true)); });};
 
 
-ScriptGenerator.prototype.generateAspNetCoreScript = function ScriptGenerator_prototype_generateAspNetCoreScript__14(templateFileName, options, _) { var fixedAspNetCoreProject, fixedRestore, fixedSolutionPath, lowerCaseScriptType, templateContent, __this = this; var __frame = { name: "ScriptGenerator_prototype_generateAspNetCoreScript__14", line: 456 }; return __func(_, this, arguments, ScriptGenerator_prototype_generateAspNetCoreScript__14, 2, __frame, function __$ScriptGenerator_prototype_generateAspNetCoreScript__14() {
+ScriptGenerator.prototype.generateAspNetCoreScript = function ScriptGenerator_prototype_generateAspNetCoreScript__15(templateFileName, options, _) { var fixedAspNetCoreProject, fixedRestore, fixedSolutionPath, lowerCaseScriptType, templateContent, __this = this; var __frame = { name: "ScriptGenerator_prototype_generateAspNetCoreScript__15", line: 468 }; return __func(_, this, arguments, ScriptGenerator_prototype_generateAspNetCoreScript__15, 2, __frame, function __$ScriptGenerator_prototype_generateAspNetCoreScript__15() {
     argNotNull(templateFileName, "templateFileName");
 
     fixedAspNetCoreProject = ((__this.scriptType === ScriptType.batch) ? fixPathSeperatorToWindows(options.aspNetCoreProject) : fixPathSeperatorToUnix(options.aspNetCoreProject));
@@ -503,7 +515,7 @@ function fixLineEndingsToWindows(contentStr) {
   return contentStr.replace(/(?:\r\n|\n)/g, "\r\n");};
 
 
-ScriptGenerator.prototype.writeDeploymentFiles = function ScriptGenerator_prototype_writeDeploymentFiles__15(templateContent, _) { var deployScriptFileName, deploymentCommand, deployScriptPath, deploymentFilePath, __this = this; var __frame = { name: "ScriptGenerator_prototype_writeDeploymentFiles__15", line: 506 }; return __func(_, this, arguments, ScriptGenerator_prototype_writeDeploymentFiles__15, 1, __frame, function __$ScriptGenerator_prototype_writeDeploymentFiles__15() {
+ScriptGenerator.prototype.writeDeploymentFiles = function ScriptGenerator_prototype_writeDeploymentFiles__16(templateContent, _) { var deployScriptFileName, deploymentCommand, deployScriptPath, deploymentFilePath, __this = this; var __frame = { name: "ScriptGenerator_prototype_writeDeploymentFiles__16", line: 518 }; return __func(_, this, arguments, ScriptGenerator_prototype_writeDeploymentFiles__16, 1, __frame, function __$ScriptGenerator_prototype_writeDeploymentFiles__16() {
     argNotNull(templateContent, "templateContent");
 
 
@@ -526,11 +538,11 @@ ScriptGenerator.prototype.writeDeploymentFiles = function ScriptGenerator_protot
     deploymentFilePath = path.join(__this.repositoryRoot, ".deployment");
 
 
-    return writeContentToFile(deployScriptPath, templateContent, __cb(_, __frame, 23, 2, function __$ScriptGenerator_prototype_writeDeploymentFiles__15() { return (function __$ScriptGenerator_prototype_writeDeploymentFiles__15(__then) {
+    return writeContentToFile(deployScriptPath, templateContent, __cb(_, __frame, 23, 2, function __$ScriptGenerator_prototype_writeDeploymentFiles__16() { return (function __$ScriptGenerator_prototype_writeDeploymentFiles__16(__then) {
 
         if (!__this.noDotDeployment) {
 
-          return writeContentToFile(deploymentFilePath, ("[config]\ncommand = " + deploymentCommand), __cb(_, __frame, 27, 4, __then, true)); } else { __then(); } ; })(function __$ScriptGenerator_prototype_writeDeploymentFiles__15() {
+          return writeContentToFile(deploymentFilePath, ("[config]\ncommand = " + deploymentCommand), __cb(_, __frame, 27, 4, __then, true)); } else { __then(); } ; })(function __$ScriptGenerator_prototype_writeDeploymentFiles__16() {
 
 
         log.info("Generated deployment script files"); _(); }); }, true)); });};
@@ -544,7 +556,7 @@ function getTemplatePath(fileName) {
   return path.join(templatesDir, fileName);};
 
 
-function writeContentToFile(path, content, _) { var __frame = { name: "writeContentToFile", line: 547 }; return __func(_, this, arguments, writeContentToFile, 2, __frame, function __$writeContentToFile() { return (function __$writeContentToFile(__then) {
+function writeContentToFile(path, content, _) { var __frame = { name: "writeContentToFile", line: 559 }; return __func(_, this, arguments, writeContentToFile, 2, __frame, function __$writeContentToFile() { return (function __$writeContentToFile(__then) {
 
       if (fs.existsSync(path)) {
         return confirm((("The file: \"" + path) + "\" already exists\nAre you sure you want to overwrite it (y/n): "), __cb(_, __frame, 3, 9, function ___(__0, __2) { var __1 = !__2; return (function __$writeContentToFile(__then) { if (__1) { return _(null); } else { __then(); } ; })(__then); }, true)); } else { __then(); } ; })(function __$writeContentToFile() {

--- a/lib/templates/deploy.bash.php.template
+++ b/lib/templates/deploy.bash.php.template
@@ -2,13 +2,13 @@
 # -----------
 
 initializeDeploymentConfig() {
-	if [ ! -e "$COMPOSERARGS" ]; then
-    COMPOSERARGS="--no-interaction --prefer-dist --optimize-autoloader --no-progress --no-dev --verbose"
-    echo "No COMPOSERARGS variable declared in App Settings, using the default settings"
+	if [ ! -e "$COMPOSER_ARGS" ]; then
+    COMPOSER_ARGS="--no-interaction --prefer-dist --optimize-autoloader --no-progress --no-dev --verbose"
+    echo "No COMPOSER_ARGS variable declared in App Settings, using the default settings"
   else
-    echo "Using COMPOSERARGS variable declared in App Setting"
+    echo "Using COMPOSER_ARGS variable declared in App Setting"
   fi
-  echo "Composer settings: $COMPOSERARGS"
+  echo "Composer settings: $COMPOSER_ARGS"
 }
 
 ##################################################################################################################################
@@ -35,7 +35,7 @@ echo "$DEPLOYMENT_TARGET"
 if [ -e "$DEPLOYMENT_TARGET/composer.json" ]; then
   echo "Found composer.json"
   pushd "$DEPLOYMENT_TARGET"
-  composer install $COMPOSERARGS
+  composer install $COMPOSER_ARGS
   exitWithMessageOnError "Composer install failed"
   popd
 fi

--- a/lib/templates/deploy.bash.php.template
+++ b/lib/templates/deploy.bash.php.template
@@ -1,0 +1,42 @@
+# PHP Helpers
+# -----------
+
+initializeDeploymentConfig() {
+	if [ ! -e "$composerArgs" ]; then
+    composerArgs="--no-interaction --prefer-dist --optimize-autoloader --no-progress --no-dev --verbose"
+    echo "No composerArg variable declared in App Settings, using the default settings"
+  else
+    echo "Using composerArg variable delcared in App Setting"
+  fi
+  echo "Composer settings: $composerArgs"
+}
+
+##################################################################################################################################
+# Deployment
+# ----------
+
+echo PHP deployment
+
+# 1. KuduSync
+if [[ "$IN_PLACE_DEPLOYMENT" -ne "1" ]]; then
+  "$KUDU_SYNC_CMD" -v 50 -f "$DEPLOYMENT_SOURCE{SitePath}" -t "$DEPLOYMENT_TARGET" -n "$NEXT_MANIFEST_PATH" -p "$PREVIOUS_MANIFEST_PATH" -i ".git;.hg;.deployment;deploy.sh"
+  exitWithMessageOnError "Kudu Sync failed"
+fi
+
+# 2. Verify composer installed
+hash composer 2>/dev/null
+exitWithMessageOnError "Missing composer executable"
+
+# 3. Initialize Composer Config
+initializeDeploymentConfig
+
+# 4. Use composer
+echo "$DEPLOYMENT_TARGET"
+if [ -e "$DEPLOYMENT_TARGET/composer.json" ]; then
+  echo "Found composer.json"
+  pushd "$DEPLOYMENT_TARGET"
+  composer install $composerArgs
+  exitWithMessageOnError "Composer install failed"
+  popd
+fi
+##################################################################################################################################

--- a/lib/templates/deploy.bash.php.template
+++ b/lib/templates/deploy.bash.php.template
@@ -6,7 +6,7 @@ initializeDeploymentConfig() {
     COMPOSERARGS="--no-interaction --prefer-dist --optimize-autoloader --no-progress --no-dev --verbose"
     echo "No COMPOSERARGS variable declared in App Settings, using the default settings"
   else
-    echo "Using COMPOSERARGS variable delcared in App Setting"
+    echo "Using COMPOSERARGS variable declared in App Setting"
   fi
   echo "Composer settings: $COMPOSERARGS"
 }

--- a/lib/templates/deploy.bash.php.template
+++ b/lib/templates/deploy.bash.php.template
@@ -2,13 +2,13 @@
 # -----------
 
 initializeDeploymentConfig() {
-	if [ ! -e "$composerArgs" ]; then
-    composerArgs="--no-interaction --prefer-dist --optimize-autoloader --no-progress --no-dev --verbose"
-    echo "No composerArg variable declared in App Settings, using the default settings"
+	if [ ! -e "$COMPOSERARGS" ]; then
+    COMPOSERARGS="--no-interaction --prefer-dist --optimize-autoloader --no-progress --no-dev --verbose"
+    echo "No COMPOSERARGS variable declared in App Settings, using the default settings"
   else
-    echo "Using composerArg variable delcared in App Setting"
+    echo "Using COMPOSERARGS variable delcared in App Setting"
   fi
-  echo "Composer settings: $composerArgs"
+  echo "Composer settings: $COMPOSERARGS"
 }
 
 ##################################################################################################################################
@@ -35,7 +35,7 @@ echo "$DEPLOYMENT_TARGET"
 if [ -e "$DEPLOYMENT_TARGET/composer.json" ]; then
   echo "Found composer.json"
   pushd "$DEPLOYMENT_TARGET"
-  composer install $composerArgs
+  composer install $COMPOSERARGS
   exitWithMessageOnError "Composer install failed"
   popd
 fi

--- a/test/smokeTest.js
+++ b/test/smokeTest.js
@@ -50,6 +50,12 @@ suite('Kudu Script Smoke Tests', function () {
         runScenario("--node", scriptType, done);
     });
 
+    test('PHP generated bash script runs without a failure', function (done) {
+        generateFile(pathUtil.join(testDir, "composer.json"), "content");
+        var scriptType = ScriptType.bash;
+        runScenario("--php", scriptType, done);
+    });
+
     test('Basic generated posh script runs without a failure', function (done) {
         generateFile(pathUtil.join(testDir, "server.js"), "content");
         var scriptType = ScriptType.posh;


### PR DESCRIPTION
Now that kudu container on Azure App Service on Linux has PHP and composer support (cf Azure-App-Service/kudu#15), it seems a great time for kudu to have a php deployment script template.
PHP detection logic has been submitted on https://github.com/projectkudu/kudu/pull/2405
This PR was inspired from the Ruby support at #58 and #64 