### PR TITLE
ruby: change bundle install command

### DIFF
--- a/lib/templates/deploy.bash.ruby.template
+++ b/lib/templates/deploy.bash.ruby.template
@@ -42,7 +42,7 @@ if [ -e "$DEPLOYMENT_TARGET/Gemfile" ]; then
   echo "Running bundle clean"
   bundle clean --force
   echo "Running bundle install"
-  bundle install --deployment $OPTIONS
+  bundle install --path "vendor/bundle" $OPTIONS
   echo "Running bundle package"
   bundle package --all
   exitWithMessageOnError "bundler failed"


### PR DESCRIPTION
--deployment switch causes issues with vendor/cache folder. If anything, the cache should be utilized in the site startup but not the deployment scenario. 