### PR TITLE
never do in place deployment for function app

### DIFF
--- a/lib/templates/deploy.batch.functionApp.template
+++ b/lib/templates/deploy.batch.functionApp.template
@@ -45,10 +45,8 @@ setlocal
 echo Not using funcpack because SCM_USE_FUNCPACK is not set to 1
 
 :: 1. KuduSync
-IF /I "%IN_PLACE_DEPLOYMENT%" NEQ "1" (
-  call :ExecuteCmd "%KUDU_SYNC_CMD%" -v 50 -f "%DEPLOYMENT_SOURCE%" -t "%DEPLOYMENT_TARGET%" -n "%NEXT_MANIFEST_PATH%" -p "%PREVIOUS_MANIFEST_PATH%" -i ".git;.hg;.deployment;deploy.cmd"
-  IF !ERRORLEVEL! NEQ 0 goto error
-)
+call :ExecuteCmd "%KUDU_SYNC_CMD%" -v 50 -f "%DEPLOYMENT_SOURCE%" -t "%DEPLOYMENT_TARGET%" -n "%NEXT_MANIFEST_PATH%" -p "%PREVIOUS_MANIFEST_PATH%" -i ".git;.hg;.deployment;deploy.cmd"
+IF !ERRORLEVEL! NEQ 0 goto error
 
 :: 2. Restore npm
 call :RestoreNpmPackages "%DEPLOYMENT_TARGET%"


### PR DESCRIPTION
we do `kudusync` regardless of whether the `SCM_USE_FUNCTION` flag is used (in place deployment is disabled for functionApp: we always copy the repo from `wwwroot/` to `repository/`) 

see this [pullrequest](https://github.com/projectkudu/kudu/pull/2416)