### PR TITLE
Revising deploy.bash.node.template

### DIFF
--- a/lib/templates/deploy.bash.node.template
+++ b/lib/templates/deploy.bash.node.template
@@ -7,24 +7,16 @@ selectNodeVersion () {
     eval $SELECT_NODE_VERSION
     exitWithMessageOnError "select node version failed"
 
-    if [[ -e "$DEPLOYMENT_TEMP/__nodeVersion.tmp" ]]; then
+    if [[ -e "$DEPLOYMENT_TEMP/__nodeVersion.tmp" ]] && [[ -e "$DEPLOYMENT_TEMP/__npmVersion.tmp" ]]; then
       NODE_EXE=`cat "$DEPLOYMENT_TEMP/__nodeVersion.tmp"`
-      exitWithMessageOnError "getting node version failed"
-    fi
-    
-    if [[ -e "$DEPLOYMENT_TEMP/__npmVersion.tmp" ]]; then
-      NPM_JS_PATH=`cat "$DEPLOYMENT_TEMP/__npmVersion.tmp"`
-      exitWithMessageOnError "getting npm version failed"
+      NPM_EXE=`cat "$DEPLOYMENT_TEMP/__npmVersion.tmp"`
+      NPM_CMD="\"$NODE_EXE\" \"$NPM_EXE\""
+    else
+      NPM_CMD=npm
     fi
 
-    if [[ ! -n "$NODE_EXE" ]]; then
-      NODE_EXE=node
-    fi
-
-    NPM_CMD="\"$NODE_EXE\" \"$NPM_JS_PATH\""
   else
     NPM_CMD=npm
-    NODE_EXE=node
   fi
 }
 
@@ -46,6 +38,7 @@ selectNodeVersion
 # 3. Install npm packages
 if [ -e "$DEPLOYMENT_TARGET/package.json" ]; then
   cd "$DEPLOYMENT_TARGET"
+  echo "Running $NPM_CMD install --production"
   eval $NPM_CMD install --production
   exitWithMessageOnError "npm failed"
   cd - > /dev/null


### PR DESCRIPTION
Cleaning up deployment script logic for node.
- No longer use $NPM_JS_PATH; Kudu doesn't set it correctly on Linux, and it's really not needed on Linux.
- Simpler: unless selectNodeVersion.js successfully computes versions for both node and npm, just do default everything.
- Logging for visibility