### PR TITLE
Change ruby deployment scenario

### DIFF
--- a/lib/templates/deploy.bash.ruby.template
+++ b/lib/templates/deploy.bash.ruby.template
@@ -1,6 +1,12 @@
 # Rails Helpers
 # -----------
 
+setLatestRubyVersion(){
+    # Hardcoded to 2.3.3 for now until we support more versions
+	LATEST_RUBY_VERSION=2.3.3
+	echo "Using ruby version $LATEST_RUBY_VERSION"
+}
+
 initializeDeploymentConfig() {
 	if [ -z $BUNDLE_WITHOUT ]; then 
 		echo "Bundle install with no 'without' options"; 
@@ -9,11 +15,25 @@ initializeDeploymentConfig() {
 		OPTIONS="--without $BUNDLE_WITHOUT";
 		echo "Bundle install with options $OPTIONS";
 	fi
+	
+	if [ -z $BUNDLE_INSTALL_LOCATION ]; then 
+		echo "Defaulting gem installation directory to /tmp/bundle"; 
+		BUNDLE_INSTALL_LOCATION="/tmp/bundle";
+	else 
+		echo "Gem installation directory is $BUNDLE_INSTALL_LOCATION";
+	fi
+	
+	if [ -z $SITE_CONFIG_DIR ]; then 
+		echo "Defaulting site config directory to /home/site/config"; 
+		SITE_CONFIG_DIR="/home/site/config"
+	else 
+		echo "site config directory is $SITE_CONFIG_DIR";
+	fi
+	
+	setLatestRubyVersion
 }
 
-setLatestNodeVersion(){
-	WEBSITES_LATEST_NODE_VERSION=$(rbenv install -l | grep -v - | grep 2.3 | tail -n 1);
-}
+
 
 ##################################################################################################################################
 # Deployment
@@ -38,7 +58,7 @@ if [ -e "$DEPLOYMENT_TARGET/Gemfile" ]; then
   exitWithMessageOnError "init failed"
   
   echo "Setting ruby version"
-  rbenv global $WEBSITES_LATEST_NODE_VERSION
+  rbenv global $LATEST_RUBY_VERSION
   exitWithMessageOnError "Failed to switch ruby versions"
   
   echo "Running bundle clean"
@@ -46,18 +66,18 @@ if [ -e "$DEPLOYMENT_TARGET/Gemfile" ]; then
   
   echo "Running bundle install"
   mkdir -p /tmp/bundle
-  bundle config --global path /tmp/bundle
-  bundle install --no-deployment
+  bundle config --global path $BUNDLE_INSTALL_LOCATION
+  bundle install --no-deployment $OPTIONS
   exitWithMessageOnError "bundler failed"
   
   echo "Zipping up bundle contents"
-  tar -zcf /tmp/gems.tgz -C /tmp/bundle .
+  tar -zcf /tmp/gems.tgz -C $BUNDLE_INSTALL_LOCATION .
   exitWithMessageOnError "Error compressing gems"
   
-  mkdir -p /home/site/config
+  mkdir -p $SITE_CONFIG_DIR
   exitWithMessageOnError "Error making config directory"
   
-  cp -f /tmp/gems.tgz /home/site/config
+  cp -f /tmp/gems.tgz $SITE_CONFIG_DIR
   
   if [ "$ASSETS_PRECOMPILE" == true ]; then 
 	echo "running rake assets:precompile"

--- a/lib/templates/deploy.bash.ruby.template
+++ b/lib/templates/deploy.bash.ruby.template
@@ -2,18 +2,17 @@
 # -----------
 
 setLatestRubyVersion(){
-    # Hardcoded to 2.3.3 for now until we support more versions
-	LATEST_RUBY_VERSION=2.3.3
+	LATEST_RUBY_VERSION=$(ls /usr/local/.rbenv/versions | grep -v - | grep 2.3 | tail -n 1)
 	echo "Using ruby version $LATEST_RUBY_VERSION"
 }
 
 initializeDeploymentConfig() {
 	if [ -z $BUNDLE_WITHOUT ]; then 
 		echo "Bundle install with no 'without' options"; 
-		OPTIONS="";
+		RUBY_OPTIONS="";
 	else 
-		OPTIONS="--without $BUNDLE_WITHOUT";
-		echo "Bundle install with options $OPTIONS";
+		RUBY_OPTIONS="--without $BUNDLE_WITHOUT";
+		echo "Bundle install with options $RUBY_OPTIONS";
 	fi
 	
 	if [ -z $BUNDLE_INSTALL_LOCATION ]; then 
@@ -23,11 +22,11 @@ initializeDeploymentConfig() {
 		echo "Gem installation directory is $BUNDLE_INSTALL_LOCATION";
 	fi
 	
-	if [ -z $SITE_CONFIG_DIR ]; then 
+	if [ -z $RUBY_SITE_CONFIG_DIR ]; then 
 		echo "Defaulting site config directory to /home/site/config"; 
-		SITE_CONFIG_DIR="/home/site/config"
+		RUBY_SITE_CONFIG_DIR="/home/site/config"
 	else 
-		echo "site config directory is $SITE_CONFIG_DIR";
+		echo "site config directory is $RUBY_SITE_CONFIG_DIR";
 	fi
 	
 	setLatestRubyVersion
@@ -65,19 +64,19 @@ if [ -e "$DEPLOYMENT_TARGET/Gemfile" ]; then
   bundle clean --force
   
   echo "Running bundle install"
-  mkdir -p /tmp/bundle
+  mkdir -p $BUNDLE_INSTALL_LOCATION
   bundle config --global path $BUNDLE_INSTALL_LOCATION
-  bundle install --no-deployment $OPTIONS
+  bundle install --no-deployment $RUBY_OPTIONS
   exitWithMessageOnError "bundler failed"
   
   echo "Zipping up bundle contents"
   tar -zcf /tmp/gems.tgz -C $BUNDLE_INSTALL_LOCATION .
   exitWithMessageOnError "Error compressing gems"
   
-  mkdir -p $SITE_CONFIG_DIR
+  mkdir -p $RUBY_SITE_CONFIG_DIR
   exitWithMessageOnError "Error making config directory"
   
-  cp -f /tmp/gems.tgz $SITE_CONFIG_DIR
+  mv -f /tmp/gems.tgz $RUBY_SITE_CONFIG_DIR
   
   if [ "$ASSETS_PRECOMPILE" == true ]; then 
 	echo "running rake assets:precompile"

--- a/lib/templates/deploy.bash.ruby.template
+++ b/lib/templates/deploy.bash.ruby.template
@@ -33,19 +33,32 @@ echo "$DEPLOYMENT_TARGET"
 if [ -e "$DEPLOYMENT_TARGET/Gemfile" ]; then
   echo "Found gemfile"
   pushd "$DEPLOYMENT_TARGET"
+  
   eval "$(rbenv init -)"
   exitWithMessageOnError "init failed"
+  
   echo "Setting ruby version"
   rbenv global $WEBSITES_LATEST_NODE_VERSION
   exitWithMessageOnError "Failed to switch ruby versions"
-  bundle config --local path "vendor/bundle"
+  
   echo "Running bundle clean"
   bundle clean --force
+  
   echo "Running bundle install"
-  bundle install --path "vendor/bundle" $OPTIONS
-  echo "Running bundle package"
-  bundle package --all
+  mkdir -p /tmp/bundle
+  bundle config --global path /tmp/bundle
+  bundle install --no-deployment
   exitWithMessageOnError "bundler failed"
+  
+  echo "Zipping up bundle contents"
+  tar -zcf /tmp/gems.tgz -C /tmp/bundle .
+  exitWithMessageOnError "Error compressing gems"
+  
+  mkdir -p /home/site/config
+  exitWithMessageOnError "Error making config directory"
+  
+  cp -f /tmp/gems.tgz /home/site/config
+  
   if [ "$ASSETS_PRECOMPILE" == true ]; then 
 	echo "running rake assets:precompile"
     bundle exec rake --trace assets:precompile


### PR DESCRIPTION
New ruby deployment scenario to greatly increase performance: 

Install bundle gems locally to /tmp/bundle 
Zip /tmp/bundle and copy that to /home/site/config directory

Ruby image will unzip the payload into /tmp/bundle in the site container and the site will load its dependencies from that directory.
This script will only work with ruby image 2.3-2 so it cannot be deployed to prod before 2.3-2 is.