### PR TITLE
Updating for Linux .NET core

### DIFF
--- a/lib/generator._js
+++ b/lib/generator._js
@@ -297,10 +297,6 @@ ScriptGenerator.prototype.generateWapDeploymentScript = function (_) {
 ScriptGenerator.prototype.generateAspNetCoreDeploymentScript = function (_) {
   argNotNull(this.absoluteProjectPath, 'absoluteProjectPath');
 
-  if (this.scriptType != ScriptType.batch && this.scriptType != ScriptType.posh) {
-      // TODO what's the support on linux
-    throw new Error('Only batch and posh script files are supported for ASP.NET Core Application');
-  }
   // this.solutionPath and this.projectPath are both relative
 
   // restore needs to be performed over the entire solution (multiple projects)
@@ -458,9 +454,8 @@ ScriptGenerator.prototype.generateDotNetDeploymentScript = function (templateFil
 ScriptGenerator.prototype.generateAspNetCoreScript = function (templateFileName, options, _) {
   argNotNull(templateFileName, 'templateFileName');
 
-  var fixedAspNetCoreProject = this.scriptType === ScriptType.batch ? fixPathSeperatorToWindows(options.aspNetCoreProject) : fixPathSeperatorToUnix(options.aspNetCoreProject);
-  var fixedRestore = this.scriptType === ScriptType.batch ? fixPathSeperatorToWindows(options.restore) : fixPathSeperatorToUnix(options.restore);
-  var fixedSolutionPath = this.scriptType === ScriptType.batch ? fixPathSeperatorToWindows(options.solutionPath) : fixPathSeperatorToUnix(options.solutionPath);
+  var fixedDotnetpublishArguments = this.scriptType === ScriptType.batch ? fixPathSeperatorToWindows(options.DotnetpublishArguments) : fixPathSeperatorToUnix(options.DotnetpublishArguments);
+  var fixedRestoreArguments = this.scriptType === ScriptType.batch ? fixPathSeperatorToWindows(options.RestoreArguments) : fixPathSeperatorToUnix(options.RestoreArguments);
 
   var lowerCaseScriptType = this.scriptType.toLowerCase();
   var templateContent = getTemplatesContent([
@@ -468,8 +463,8 @@ ScriptGenerator.prototype.generateAspNetCoreScript = function (templateFileName,
     'deploy.' + lowerCaseScriptType + '.aspnet.template',
     'deploy.' + lowerCaseScriptType + '.' + templateFileName,
     'deploy.' + lowerCaseScriptType + '.postfix.template'
-]).replace(/{DotnetpublishArguments}/g, options.DotnetpublishArguments)
-    .replace(/{RestoreArguments}/g, options.RestoreArguments)
+]).replace(/{DotnetpublishArguments}/g, fixedDotnetpublishArguments)
+    .replace(/{RestoreArguments}/g, fixedRestoreArguments)
     .replace(/{MSBuildArguments}/g, options.MSBuildArguments)
     .replace(/{MSPublishArguments}/g, options.MSPublishArguments);
 

--- a/lib/generator.js
+++ b/lib/generator.js
@@ -297,10 +297,6 @@ ScriptGenerator.prototype.generateWapDeploymentScript = function ScriptGenerator
 ScriptGenerator.prototype.generateAspNetCoreDeploymentScript = function ScriptGenerator_prototype_generateAspNetCoreDeploymentScript__9(_) { var options, __this = this; var __frame = { name: "ScriptGenerator_prototype_generateAspNetCoreDeploymentScript__9", line: 297 }; return __func(_, this, arguments, ScriptGenerator_prototype_generateAspNetCoreDeploymentScript__9, 0, __frame, function __$ScriptGenerator_prototype_generateAspNetCoreDeploymentScript__9() {
     argNotNull(__this.absoluteProjectPath, "absoluteProjectPath");
 
-    if (((__this.scriptType != ScriptType.batch) && (__this.scriptType != ScriptType.posh))) {
-
-      return _(new Error("Only batch and posh script files are supported for ASP.NET Core Application")); } ;
-
 
 
 
@@ -310,11 +306,11 @@ ScriptGenerator.prototype.generateAspNetCoreDeploymentScript = function ScriptGe
 
         options.MSBuildArguments = options.RestoreArguments;
         options.MSPublishArguments = __this.projectPath;
-        return __this.generateAspNetCoreScript("aspnet.core.msbuild14.template", options, __cb(_, __frame, 16, 6, __then, true)); } else {
+        return __this.generateAspNetCoreScript("aspnet.core.msbuild14.template", options, __cb(_, __frame, 12, 6, __then, true)); } else {
 
 
         options.DotnetpublishArguments = __this.projectPath;
-        return __this.generateAspNetCoreScript("aspnet.core.template", options, __cb(_, __frame, 20, 6, __then, true)); } ; })(_); });};
+        return __this.generateAspNetCoreScript("aspnet.core.template", options, __cb(_, __frame, 16, 6, __then, true)); } ; })(_); });};
 
 
 
@@ -337,7 +333,7 @@ ScriptGenerator.prototype.generateAspNetCoreDeploymentScript = function ScriptGe
 
 
 
-ScriptGenerator.prototype.generateDnxConsoleAppDeploymentScript = function ScriptGenerator_prototype_generateDnxConsoleAppDeploymentScript__10(_) { var options, __this = this; var __frame = { name: "ScriptGenerator_prototype_generateDnxConsoleAppDeploymentScript__10", line: 340 }; return __func(_, this, arguments, ScriptGenerator_prototype_generateDnxConsoleAppDeploymentScript__10, 0, __frame, function __$ScriptGenerator_prototype_generateDnxConsoleAppDeploymentScript__10() {
+ScriptGenerator.prototype.generateDnxConsoleAppDeploymentScript = function ScriptGenerator_prototype_generateDnxConsoleAppDeploymentScript__10(_) { var options, __this = this; var __frame = { name: "ScriptGenerator_prototype_generateDnxConsoleAppDeploymentScript__10", line: 336 }; return __func(_, this, arguments, ScriptGenerator_prototype_generateDnxConsoleAppDeploymentScript__10, 0, __frame, function __$ScriptGenerator_prototype_generateDnxConsoleAppDeploymentScript__10() {
     if ((__this.scriptType != ScriptType.batch)) {
       return _(new Error("Only batch script files are supported for DNX Console Application")); } ;
 
@@ -351,7 +347,7 @@ ScriptGenerator.prototype.generateDnxConsoleAppDeploymentScript = function Scrip
     return __this.generateDnxConsoleAppScript("deploy.batch.dnx.consoleapp.template", options, __cb(_, __frame, 11, 2, _, true)); });};
 
 
-ScriptGenerator.prototype.generateDotNetConsoleDeploymentScript = function ScriptGenerator_prototype_generateDotNetConsoleDeploymentScript__11(_) { var msbuildArguments, solutionDir, solutionArgs, options, __this = this; var __frame = { name: "ScriptGenerator_prototype_generateDotNetConsoleDeploymentScript__11", line: 354 }; return __func(_, this, arguments, ScriptGenerator_prototype_generateDotNetConsoleDeploymentScript__11, 0, __frame, function __$ScriptGenerator_prototype_generateDotNetConsoleDeploymentScript__11() {
+ScriptGenerator.prototype.generateDotNetConsoleDeploymentScript = function ScriptGenerator_prototype_generateDotNetConsoleDeploymentScript__11(_) { var msbuildArguments, solutionDir, solutionArgs, options, __this = this; var __frame = { name: "ScriptGenerator_prototype_generateDotNetConsoleDeploymentScript__11", line: 350 }; return __func(_, this, arguments, ScriptGenerator_prototype_generateDotNetConsoleDeploymentScript__11, 0, __frame, function __$ScriptGenerator_prototype_generateDotNetConsoleDeploymentScript__11() {
     argNotNull(__this.projectPath, "projectPath");
 
     if (((__this.scriptType != ScriptType.batch) && (__this.scriptType != ScriptType.posh))) {
@@ -396,7 +392,7 @@ ScriptGenerator.prototype.generateDotNetConsoleDeploymentScript = function Scrip
     return __this.generateDotNetDeploymentScript("dotnetconsole.template", options, __cb(_, __frame, 42, 2, _, true)); });};
 
 
-ScriptGenerator.prototype.generateWebSiteDeploymentScript = function ScriptGenerator_prototype_generateWebSiteDeploymentScript__12(_) { var msbuildArguments, __this = this; var __frame = { name: "ScriptGenerator_prototype_generateWebSiteDeploymentScript__12", line: 399 }; return __func(_, this, arguments, ScriptGenerator_prototype_generateWebSiteDeploymentScript__12, 0, __frame, function __$ScriptGenerator_prototype_generateWebSiteDeploymentScript__12() { return (function __$ScriptGenerator_prototype_generateWebSiteDeploymentScript__12(__then) {
+ScriptGenerator.prototype.generateWebSiteDeploymentScript = function ScriptGenerator_prototype_generateWebSiteDeploymentScript__12(_) { var msbuildArguments, __this = this; var __frame = { name: "ScriptGenerator_prototype_generateWebSiteDeploymentScript__12", line: 395 }; return __func(_, this, arguments, ScriptGenerator_prototype_generateWebSiteDeploymentScript__12, 0, __frame, function __$ScriptGenerator_prototype_generateWebSiteDeploymentScript__12() { return (function __$ScriptGenerator_prototype_generateWebSiteDeploymentScript__12(__then) {
       if (__this.solutionPath) {
 
         log.info("Generating deployment script for .NET Web Site");
@@ -421,7 +417,7 @@ ScriptGenerator.prototype.generateWebSiteDeploymentScript = function ScriptGener
 
 
 
-ScriptGenerator.prototype.generateBasicDeploymentScript = function ScriptGenerator_prototype_generateBasicDeploymentScript__13(templateFileName, _) { var lowerCaseScriptType, fixedSitePath, templateContent, __this = this; var __frame = { name: "ScriptGenerator_prototype_generateBasicDeploymentScript__13", line: 424 }; return __func(_, this, arguments, ScriptGenerator_prototype_generateBasicDeploymentScript__13, 1, __frame, function __$ScriptGenerator_prototype_generateBasicDeploymentScript__13() {
+ScriptGenerator.prototype.generateBasicDeploymentScript = function ScriptGenerator_prototype_generateBasicDeploymentScript__13(templateFileName, _) { var lowerCaseScriptType, fixedSitePath, templateContent, __this = this; var __frame = { name: "ScriptGenerator_prototype_generateBasicDeploymentScript__13", line: 420 }; return __func(_, this, arguments, ScriptGenerator_prototype_generateBasicDeploymentScript__13, 1, __frame, function __$ScriptGenerator_prototype_generateBasicDeploymentScript__13() {
     argNotNull(templateFileName, "templateFileName");
 
     lowerCaseScriptType = __this.scriptType.toLowerCase();
@@ -435,7 +431,7 @@ ScriptGenerator.prototype.generateBasicDeploymentScript = function ScriptGenerat
     return __this.writeDeploymentFiles(templateContent, __cb(_, __frame, 11, 2, _, true)); });};
 
 
-ScriptGenerator.prototype.generateDotNetDeploymentScript = function ScriptGenerator_prototype_generateDotNetDeploymentScript__14(templateFileName, options, _) { var lowerCaseScriptType, solutionDir, templateContent, __this = this; var __frame = { name: "ScriptGenerator_prototype_generateDotNetDeploymentScript__14", line: 438 }; return __func(_, this, arguments, ScriptGenerator_prototype_generateDotNetDeploymentScript__14, 2, __frame, function __$ScriptGenerator_prototype_generateDotNetDeploymentScript__14() {
+ScriptGenerator.prototype.generateDotNetDeploymentScript = function ScriptGenerator_prototype_generateDotNetDeploymentScript__14(templateFileName, options, _) { var lowerCaseScriptType, solutionDir, templateContent, __this = this; var __frame = { name: "ScriptGenerator_prototype_generateDotNetDeploymentScript__14", line: 434 }; return __func(_, this, arguments, ScriptGenerator_prototype_generateDotNetDeploymentScript__14, 2, __frame, function __$ScriptGenerator_prototype_generateDotNetDeploymentScript__14() {
     argNotNull(templateFileName, "templateFileName");
 
 
@@ -455,12 +451,11 @@ ScriptGenerator.prototype.generateDotNetDeploymentScript = function ScriptGenera
     return __this.writeDeploymentFiles(templateContent, __cb(_, __frame, 17, 2, _, true)); });};
 
 
-ScriptGenerator.prototype.generateAspNetCoreScript = function ScriptGenerator_prototype_generateAspNetCoreScript__15(templateFileName, options, _) { var fixedAspNetCoreProject, fixedRestore, fixedSolutionPath, lowerCaseScriptType, templateContent, __this = this; var __frame = { name: "ScriptGenerator_prototype_generateAspNetCoreScript__15", line: 458 }; return __func(_, this, arguments, ScriptGenerator_prototype_generateAspNetCoreScript__15, 2, __frame, function __$ScriptGenerator_prototype_generateAspNetCoreScript__15() {
+ScriptGenerator.prototype.generateAspNetCoreScript = function ScriptGenerator_prototype_generateAspNetCoreScript__15(templateFileName, options, _) { var fixedDotnetpublishArguments, fixedRestoreArguments, lowerCaseScriptType, templateContent, __this = this; var __frame = { name: "ScriptGenerator_prototype_generateAspNetCoreScript__15", line: 454 }; return __func(_, this, arguments, ScriptGenerator_prototype_generateAspNetCoreScript__15, 2, __frame, function __$ScriptGenerator_prototype_generateAspNetCoreScript__15() {
     argNotNull(templateFileName, "templateFileName");
 
-    fixedAspNetCoreProject = ((__this.scriptType === ScriptType.batch) ? fixPathSeperatorToWindows(options.aspNetCoreProject) : fixPathSeperatorToUnix(options.aspNetCoreProject));
-    fixedRestore = ((__this.scriptType === ScriptType.batch) ? fixPathSeperatorToWindows(options.restore) : fixPathSeperatorToUnix(options.restore));
-    fixedSolutionPath = ((__this.scriptType === ScriptType.batch) ? fixPathSeperatorToWindows(options.solutionPath) : fixPathSeperatorToUnix(options.solutionPath));
+    fixedDotnetpublishArguments = ((__this.scriptType === ScriptType.batch) ? fixPathSeperatorToWindows(options.DotnetpublishArguments) : fixPathSeperatorToUnix(options.DotnetpublishArguments));
+    fixedRestoreArguments = ((__this.scriptType === ScriptType.batch) ? fixPathSeperatorToWindows(options.RestoreArguments) : fixPathSeperatorToUnix(options.RestoreArguments));
 
     lowerCaseScriptType = __this.scriptType.toLowerCase();
 
@@ -471,9 +466,9 @@ ScriptGenerator.prototype.generateAspNetCoreScript = function ScriptGenerator_pr
 
 
 
-    templateContent = getTemplatesContent([(("deploy." + lowerCaseScriptType) + ".prefix.template"),(("deploy." + lowerCaseScriptType) + ".aspnet.template"),((("deploy." + lowerCaseScriptType) + ".") + templateFileName),(("deploy." + lowerCaseScriptType) + ".postfix.template"),]).replace(/{DotnetpublishArguments}/g, options.DotnetpublishArguments).replace(/{RestoreArguments}/g, options.RestoreArguments).replace(/{MSBuildArguments}/g, options.MSBuildArguments).replace(/{MSPublishArguments}/g, options.MSPublishArguments);
+    templateContent = getTemplatesContent([(("deploy." + lowerCaseScriptType) + ".prefix.template"),(("deploy." + lowerCaseScriptType) + ".aspnet.template"),((("deploy." + lowerCaseScriptType) + ".") + templateFileName),(("deploy." + lowerCaseScriptType) + ".postfix.template"),]).replace(/{DotnetpublishArguments}/g, fixedDotnetpublishArguments).replace(/{RestoreArguments}/g, fixedRestoreArguments).replace(/{MSBuildArguments}/g, options.MSBuildArguments).replace(/{MSPublishArguments}/g, options.MSPublishArguments);
 
-    return __this.writeDeploymentFiles(templateContent, __cb(_, __frame, 18, 2, _, true)); });};
+    return __this.writeDeploymentFiles(templateContent, __cb(_, __frame, 17, 2, _, true)); });};
 
 
 function getTemplatesContent(fileNames) {
@@ -504,7 +499,7 @@ function fixLineEndingsToWindows(contentStr) {
   return contentStr.replace(/(?:\r\n|\n)/g, "\r\n");};
 
 
-ScriptGenerator.prototype.writeDeploymentFiles = function ScriptGenerator_prototype_writeDeploymentFiles__16(templateContent, _) { var deployScriptFileName, deploymentCommand, deployScriptPath, deploymentFilePath, __this = this; var __frame = { name: "ScriptGenerator_prototype_writeDeploymentFiles__16", line: 507 }; return __func(_, this, arguments, ScriptGenerator_prototype_writeDeploymentFiles__16, 1, __frame, function __$ScriptGenerator_prototype_writeDeploymentFiles__16() {
+ScriptGenerator.prototype.writeDeploymentFiles = function ScriptGenerator_prototype_writeDeploymentFiles__16(templateContent, _) { var deployScriptFileName, deploymentCommand, deployScriptPath, deploymentFilePath, __this = this; var __frame = { name: "ScriptGenerator_prototype_writeDeploymentFiles__16", line: 502 }; return __func(_, this, arguments, ScriptGenerator_prototype_writeDeploymentFiles__16, 1, __frame, function __$ScriptGenerator_prototype_writeDeploymentFiles__16() {
     argNotNull(templateContent, "templateContent");
 
 
@@ -545,7 +540,7 @@ function getTemplatePath(fileName) {
   return path.join(templatesDir, fileName);};
 
 
-function writeContentToFile(path, content, _) { var __frame = { name: "writeContentToFile", line: 548 }; return __func(_, this, arguments, writeContentToFile, 2, __frame, function __$writeContentToFile() { return (function __$writeContentToFile(__then) {
+function writeContentToFile(path, content, _) { var __frame = { name: "writeContentToFile", line: 543 }; return __func(_, this, arguments, writeContentToFile, 2, __frame, function __$writeContentToFile() { return (function __$writeContentToFile(__then) {
 
       if (fs.existsSync(path)) {
         return confirm((("The file: \"" + path) + "\" already exists\nAre you sure you want to overwrite it (y/n): "), __cb(_, __frame, 3, 9, function ___(__0, __2) { var __1 = !__2; return (function __$writeContentToFile(__then) { if (__1) { return _(null); } else { __then(); } ; })(__then); }, true)); } else { __then(); } ; })(function __$writeContentToFile() {

--- a/lib/templates/deploy.bash.aspnet.core.template
+++ b/lib/templates/deploy.bash.aspnet.core.template
@@ -5,11 +5,11 @@
 echo Handling ASP.NET Core Web Application deployment.
 
 # 1. Restore nuget packages
-{Restore}
+dotnet restore "$DEPLOYMENT_SOURCE/{RestoreArguments}"
 exitWithMessageOnError "dotnet restore failed"
 
 # 2. Build and publish
-dotnet publish "{PROJECT}" --output "$DEPLOYMENT_TEMP" --configuration Release
+dotnet publish "$DEPLOYMENT_SOURCE/{DotnetpublishArguments}" --output "$DEPLOYMENT_TEMP" --configuration Release
 exitWithMessageOnError "dotnet publish failed"
 
 # 3. KuduSync


### PR DESCRIPTION
Note this is a PR against shun-work.

- Removed unneeded throw if user is generating bash script for .NET Core.
- Ran directory separator fix logic for strings that can potentially go into bash scripts
- Updated bash .NET Core deployment script template with new replacement tokens. Note the line ending changes are benign; somehow it got mixed line endings in a previous checkin, this fixes.