### PR TITLE
add functionApp template for bash

### DIFF
--- a/lib/generator._js
+++ b/lib/generator._js
@@ -214,17 +214,23 @@ ScriptGenerator.prototype.generateNodeDeploymentScript = function (_) {
 ScriptGenerator.prototype.generateFunctionAppDeploymentScript = function(_) {
   log.info('Generating deployment script for function App');
 
-  if (this.scriptType != ScriptType.batch) {
-    throw new Error('Only batch script files are supported for function App');
-  }
-
   options = {}
   if (this.solutionPath) {
+    // if it has a .sln, it must be targeting windows
+    if (this.scriptType == ScriptType.bash) {
+      throw new Error('function app targeting dotnet core is currently not supported');
+    }
     options.solutionPath = fixPathSeparatorToWindows(this.solutionPath);
     options.projectPath = fixPathSeparatorToWindows(this.projectPath);
     this.generateFunctionAppScript('functionmsbuild.template', options, _);
   } else {
-    options.sitePath = fixPathSeparatorToWindows(this.sitePath);
+    if (this.scriptType == ScriptType.bash) {
+      // this template should be able to handle all three kind of functions
+      // node(tested), csx(tested), and csproj(cannot yet be created with function cli)
+      options.sitePath = fixPathSeparatorToUnix(this.sitePath);
+    } else {
+      options.sitePath = fixPathSeparatorToWindows(this.sitePath);
+    }
     this.generateFunctionAppScript('functionbasic.template', options, _);
   }
 

--- a/lib/generator.js
+++ b/lib/generator.js
@@ -214,23 +214,29 @@ ScriptGenerator.prototype.generateNodeDeploymentScript = function ScriptGenerato
 ScriptGenerator.prototype.generateFunctionAppDeploymentScript = function ScriptGenerator_prototype_generateFunctionAppDeploymentScript__4(_) { var __this = this; var __frame = { name: "ScriptGenerator_prototype_generateFunctionAppDeploymentScript__4", line: 214 }; return __func(_, this, arguments, ScriptGenerator_prototype_generateFunctionAppDeploymentScript__4, 0, __frame, function __$ScriptGenerator_prototype_generateFunctionAppDeploymentScript__4() {
     log.info("Generating deployment script for function App");
 
-    if ((__this.scriptType != ScriptType.batch)) {
-      return _(new Error("Only batch script files are supported for function App")); } ;
-
-
     options = { }; return (function __$ScriptGenerator_prototype_generateFunctionAppDeploymentScript__4(__then) {
       if (__this.solutionPath) {
+
+        if ((__this.scriptType == ScriptType.bash)) {
+          return _(new Error("function app targeting dotnet core is currently not supported")); } ;
+
         options.solutionPath = fixPathSeparatorToWindows(__this.solutionPath);
         options.projectPath = fixPathSeparatorToWindows(__this.projectPath);
         return __this.generateFunctionAppScript("functionmsbuild.template", options, __cb(_, __frame, 11, 4, __then, true)); } else {
 
-        options.sitePath = fixPathSeparatorToWindows(__this.sitePath);
-        return __this.generateFunctionAppScript("functionbasic.template", options, __cb(_, __frame, 14, 4, __then, true)); } ; })(_); });};
+        if ((__this.scriptType == ScriptType.bash)) {
+
+
+          options.sitePath = fixPathSeparatorToUnix(__this.sitePath); }
+         else {
+          options.sitePath = fixPathSeparatorToWindows(__this.sitePath); } ;
+
+        return __this.generateFunctionAppScript("functionbasic.template", options, __cb(_, __frame, 20, 4, __then, true)); } ; })(_); });};
 
 
 
 
-ScriptGenerator.prototype.generatePythonDeploymentScript = function ScriptGenerator_prototype_generatePythonDeploymentScript__5(_) { var __this = this; var __frame = { name: "ScriptGenerator_prototype_generatePythonDeploymentScript__5", line: 233 }; return __func(_, this, arguments, ScriptGenerator_prototype_generatePythonDeploymentScript__5, 0, __frame, function __$ScriptGenerator_prototype_generatePythonDeploymentScript__5() {
+ScriptGenerator.prototype.generatePythonDeploymentScript = function ScriptGenerator_prototype_generatePythonDeploymentScript__5(_) { var __this = this; var __frame = { name: "ScriptGenerator_prototype_generatePythonDeploymentScript__5", line: 239 }; return __func(_, this, arguments, ScriptGenerator_prototype_generatePythonDeploymentScript__5, 0, __frame, function __$ScriptGenerator_prototype_generatePythonDeploymentScript__5() {
     log.info("Generating deployment script for python Web Site");
 
     if ((__this.scriptType != ScriptType.batch)) {
@@ -240,19 +246,19 @@ ScriptGenerator.prototype.generatePythonDeploymentScript = function ScriptGenera
     return __this.generateBasicDeploymentScript("python.template", __cb(_, __frame, 7, 2, _, true)); });};
 
 
-ScriptGenerator.prototype.generateRubyDeploymentScript = function ScriptGenerator_prototype_generateRubyDeploymentScript__6(_) { var __this = this; var __frame = { name: "ScriptGenerator_prototype_generateRubyDeploymentScript__6", line: 243 }; return __func(_, this, arguments, ScriptGenerator_prototype_generateRubyDeploymentScript__6, 0, __frame, function __$ScriptGenerator_prototype_generateRubyDeploymentScript__6() {
+ScriptGenerator.prototype.generateRubyDeploymentScript = function ScriptGenerator_prototype_generateRubyDeploymentScript__6(_) { var __this = this; var __frame = { name: "ScriptGenerator_prototype_generateRubyDeploymentScript__6", line: 249 }; return __func(_, this, arguments, ScriptGenerator_prototype_generateRubyDeploymentScript__6, 0, __frame, function __$ScriptGenerator_prototype_generateRubyDeploymentScript__6() {
     log.info("Generating deployment script for Ruby Web Site");
 
     return __this.generateBasicDeploymentScript("ruby.template", __cb(_, __frame, 3, 2, _, true)); });};
 
 
-ScriptGenerator.prototype.generatePHPDeploymentScript = function ScriptGenerator_prototype_generatePHPDeploymentScript__7(_) { var __this = this; var __frame = { name: "ScriptGenerator_prototype_generatePHPDeploymentScript__7", line: 249 }; return __func(_, this, arguments, ScriptGenerator_prototype_generatePHPDeploymentScript__7, 0, __frame, function __$ScriptGenerator_prototype_generatePHPDeploymentScript__7() {
+ScriptGenerator.prototype.generatePHPDeploymentScript = function ScriptGenerator_prototype_generatePHPDeploymentScript__7(_) { var __this = this; var __frame = { name: "ScriptGenerator_prototype_generatePHPDeploymentScript__7", line: 255 }; return __func(_, this, arguments, ScriptGenerator_prototype_generatePHPDeploymentScript__7, 0, __frame, function __$ScriptGenerator_prototype_generatePHPDeploymentScript__7() {
     log.info("Generating deployment script for PHP Web Site");
 
     return __this.generateBasicDeploymentScript("php.template", __cb(_, __frame, 3, 2, _, true)); });};
 
 
-ScriptGenerator.prototype.generateWapDeploymentScript = function ScriptGenerator_prototype_generateWapDeploymentScript__8(_) { var msbuildArguments, msbuildArgumentsForInPlace, solutionDir, solutionArgs, options, __this = this; var __frame = { name: "ScriptGenerator_prototype_generateWapDeploymentScript__8", line: 255 }; return __func(_, this, arguments, ScriptGenerator_prototype_generateWapDeploymentScript__8, 0, __frame, function __$ScriptGenerator_prototype_generateWapDeploymentScript__8() {
+ScriptGenerator.prototype.generateWapDeploymentScript = function ScriptGenerator_prototype_generateWapDeploymentScript__8(_) { var msbuildArguments, msbuildArgumentsForInPlace, solutionDir, solutionArgs, options, __this = this; var __frame = { name: "ScriptGenerator_prototype_generateWapDeploymentScript__8", line: 261 }; return __func(_, this, arguments, ScriptGenerator_prototype_generateWapDeploymentScript__8, 0, __frame, function __$ScriptGenerator_prototype_generateWapDeploymentScript__8() {
     argNotNull(__this.projectPath, "projectPath");
 
     if (((__this.scriptType != ScriptType.batch) && (__this.scriptType != ScriptType.posh))) {
@@ -303,7 +309,7 @@ ScriptGenerator.prototype.generateWapDeploymentScript = function ScriptGenerator
     return __this.generateDotNetDeploymentScript("aspnet.wap.template", options, __cb(_, __frame, 48, 2, _, true)); });};
 
 
-ScriptGenerator.prototype.generateAspNetCoreDeploymentScript = function ScriptGenerator_prototype_generateAspNetCoreDeploymentScript__9(_) { var options, __this = this; var __frame = { name: "ScriptGenerator_prototype_generateAspNetCoreDeploymentScript__9", line: 306 }; return __func(_, this, arguments, ScriptGenerator_prototype_generateAspNetCoreDeploymentScript__9, 0, __frame, function __$ScriptGenerator_prototype_generateAspNetCoreDeploymentScript__9() {
+ScriptGenerator.prototype.generateAspNetCoreDeploymentScript = function ScriptGenerator_prototype_generateAspNetCoreDeploymentScript__9(_) { var options, __this = this; var __frame = { name: "ScriptGenerator_prototype_generateAspNetCoreDeploymentScript__9", line: 312 }; return __func(_, this, arguments, ScriptGenerator_prototype_generateAspNetCoreDeploymentScript__9, 0, __frame, function __$ScriptGenerator_prototype_generateAspNetCoreDeploymentScript__9() {
     argNotNull(__this.absoluteProjectPath, "absoluteProjectPath");
 
 
@@ -316,7 +322,7 @@ ScriptGenerator.prototype.generateAspNetCoreDeploymentScript = function ScriptGe
 
 
 
-ScriptGenerator.prototype.generateDotNetConsoleDeploymentScript = function ScriptGenerator_prototype_generateDotNetConsoleDeploymentScript__10(_) { var msbuildArguments, solutionDir, solutionArgs, options, __this = this; var __frame = { name: "ScriptGenerator_prototype_generateDotNetConsoleDeploymentScript__10", line: 319 }; return __func(_, this, arguments, ScriptGenerator_prototype_generateDotNetConsoleDeploymentScript__10, 0, __frame, function __$ScriptGenerator_prototype_generateDotNetConsoleDeploymentScript__10() {
+ScriptGenerator.prototype.generateDotNetConsoleDeploymentScript = function ScriptGenerator_prototype_generateDotNetConsoleDeploymentScript__10(_) { var msbuildArguments, solutionDir, solutionArgs, options, __this = this; var __frame = { name: "ScriptGenerator_prototype_generateDotNetConsoleDeploymentScript__10", line: 325 }; return __func(_, this, arguments, ScriptGenerator_prototype_generateDotNetConsoleDeploymentScript__10, 0, __frame, function __$ScriptGenerator_prototype_generateDotNetConsoleDeploymentScript__10() {
     argNotNull(__this.projectPath, "projectPath");
 
     if (((__this.scriptType != ScriptType.batch) && (__this.scriptType != ScriptType.posh))) {
@@ -361,7 +367,7 @@ ScriptGenerator.prototype.generateDotNetConsoleDeploymentScript = function Scrip
     return __this.generateDotNetDeploymentScript("dotnetconsole.template", options, __cb(_, __frame, 42, 2, _, true)); });};
 
 
-ScriptGenerator.prototype.generateWebSiteDeploymentScript = function ScriptGenerator_prototype_generateWebSiteDeploymentScript__11(_) { var msbuildArguments, __this = this; var __frame = { name: "ScriptGenerator_prototype_generateWebSiteDeploymentScript__11", line: 364 }; return __func(_, this, arguments, ScriptGenerator_prototype_generateWebSiteDeploymentScript__11, 0, __frame, function __$ScriptGenerator_prototype_generateWebSiteDeploymentScript__11() { return (function __$ScriptGenerator_prototype_generateWebSiteDeploymentScript__11(__then) {
+ScriptGenerator.prototype.generateWebSiteDeploymentScript = function ScriptGenerator_prototype_generateWebSiteDeploymentScript__11(_) { var msbuildArguments, __this = this; var __frame = { name: "ScriptGenerator_prototype_generateWebSiteDeploymentScript__11", line: 370 }; return __func(_, this, arguments, ScriptGenerator_prototype_generateWebSiteDeploymentScript__11, 0, __frame, function __$ScriptGenerator_prototype_generateWebSiteDeploymentScript__11() { return (function __$ScriptGenerator_prototype_generateWebSiteDeploymentScript__11(__then) {
       if (__this.solutionPath) {
 
         log.info("Generating deployment script for .NET Web Site");
@@ -386,7 +392,7 @@ ScriptGenerator.prototype.generateWebSiteDeploymentScript = function ScriptGener
 
 
 
-ScriptGenerator.prototype.generateBasicDeploymentScript = function ScriptGenerator_prototype_generateBasicDeploymentScript__12(templateFileName, _) { var lowerCaseScriptType, fixedSitePath, templateContent, __this = this; var __frame = { name: "ScriptGenerator_prototype_generateBasicDeploymentScript__12", line: 389 }; return __func(_, this, arguments, ScriptGenerator_prototype_generateBasicDeploymentScript__12, 1, __frame, function __$ScriptGenerator_prototype_generateBasicDeploymentScript__12() {
+ScriptGenerator.prototype.generateBasicDeploymentScript = function ScriptGenerator_prototype_generateBasicDeploymentScript__12(templateFileName, _) { var lowerCaseScriptType, fixedSitePath, templateContent, __this = this; var __frame = { name: "ScriptGenerator_prototype_generateBasicDeploymentScript__12", line: 395 }; return __func(_, this, arguments, ScriptGenerator_prototype_generateBasicDeploymentScript__12, 1, __frame, function __$ScriptGenerator_prototype_generateBasicDeploymentScript__12() {
     argNotNull(templateFileName, "templateFileName");
 
     lowerCaseScriptType = __this.scriptType.toLowerCase();
@@ -400,7 +406,7 @@ ScriptGenerator.prototype.generateBasicDeploymentScript = function ScriptGenerat
     return __this.writeDeploymentFiles(templateContent, __cb(_, __frame, 11, 2, _, true)); });};
 
 
-ScriptGenerator.prototype.generateFunctionAppScript = function ScriptGenerator_prototype_generateFunctionAppScript__13(templateFileName, options, _) { var lowerCaseScriptType, templateContent, __this = this; var __frame = { name: "ScriptGenerator_prototype_generateFunctionAppScript__13", line: 403 }; return __func(_, this, arguments, ScriptGenerator_prototype_generateFunctionAppScript__13, 2, __frame, function __$ScriptGenerator_prototype_generateFunctionAppScript__13() {
+ScriptGenerator.prototype.generateFunctionAppScript = function ScriptGenerator_prototype_generateFunctionAppScript__13(templateFileName, options, _) { var lowerCaseScriptType, templateContent, __this = this; var __frame = { name: "ScriptGenerator_prototype_generateFunctionAppScript__13", line: 409 }; return __func(_, this, arguments, ScriptGenerator_prototype_generateFunctionAppScript__13, 2, __frame, function __$ScriptGenerator_prototype_generateFunctionAppScript__13() {
     argNotNull(templateFileName, "templateFileName");
 
     lowerCaseScriptType = __this.scriptType.toLowerCase();
@@ -415,7 +421,7 @@ ScriptGenerator.prototype.generateFunctionAppScript = function ScriptGenerator_p
     return __this.writeDeploymentFiles(templateContent, __cb(_, __frame, 12, 2, _, true)); });};
 
 
-ScriptGenerator.prototype.generateDotNetDeploymentScript = function ScriptGenerator_prototype_generateDotNetDeploymentScript__14(templateFileName, options, _) { var lowerCaseScriptType, solutionDir, templateContent, __this = this; var __frame = { name: "ScriptGenerator_prototype_generateDotNetDeploymentScript__14", line: 418 }; return __func(_, this, arguments, ScriptGenerator_prototype_generateDotNetDeploymentScript__14, 2, __frame, function __$ScriptGenerator_prototype_generateDotNetDeploymentScript__14() {
+ScriptGenerator.prototype.generateDotNetDeploymentScript = function ScriptGenerator_prototype_generateDotNetDeploymentScript__14(templateFileName, options, _) { var lowerCaseScriptType, solutionDir, templateContent, __this = this; var __frame = { name: "ScriptGenerator_prototype_generateDotNetDeploymentScript__14", line: 424 }; return __func(_, this, arguments, ScriptGenerator_prototype_generateDotNetDeploymentScript__14, 2, __frame, function __$ScriptGenerator_prototype_generateDotNetDeploymentScript__14() {
     argNotNull(templateFileName, "templateFileName");
 
 
@@ -435,7 +441,7 @@ ScriptGenerator.prototype.generateDotNetDeploymentScript = function ScriptGenera
     return __this.writeDeploymentFiles(templateContent, __cb(_, __frame, 17, 2, _, true)); });};
 
 
-ScriptGenerator.prototype.generateAspNetCoreScript = function ScriptGenerator_prototype_generateAspNetCoreScript__15(templateFileName, options, _) { var prop, lowerCaseScriptType, templateContent, __this = this; var __frame = { name: "ScriptGenerator_prototype_generateAspNetCoreScript__15", line: 438 }; return __func(_, this, arguments, ScriptGenerator_prototype_generateAspNetCoreScript__15, 2, __frame, function __$ScriptGenerator_prototype_generateAspNetCoreScript__15() {
+ScriptGenerator.prototype.generateAspNetCoreScript = function ScriptGenerator_prototype_generateAspNetCoreScript__15(templateFileName, options, _) { var prop, lowerCaseScriptType, templateContent, __this = this; var __frame = { name: "ScriptGenerator_prototype_generateAspNetCoreScript__15", line: 444 }; return __func(_, this, arguments, ScriptGenerator_prototype_generateAspNetCoreScript__15, 2, __frame, function __$ScriptGenerator_prototype_generateAspNetCoreScript__15() {
     argNotNull(templateFileName, "templateFileName");
 
     if ((__this.scriptType === ScriptType.batch)) {
@@ -488,7 +494,7 @@ function fixLineEndingsToWindows(contentStr) {
   return contentStr.replace(/(?:\r\n|\n)/g, "\r\n");};
 
 
-ScriptGenerator.prototype.writeDeploymentFiles = function ScriptGenerator_prototype_writeDeploymentFiles__16(templateContent, _) { var deployScriptFileName, deploymentCommand, deployScriptPath, deploymentFilePath, __this = this; var __frame = { name: "ScriptGenerator_prototype_writeDeploymentFiles__16", line: 491 }; return __func(_, this, arguments, ScriptGenerator_prototype_writeDeploymentFiles__16, 1, __frame, function __$ScriptGenerator_prototype_writeDeploymentFiles__16() {
+ScriptGenerator.prototype.writeDeploymentFiles = function ScriptGenerator_prototype_writeDeploymentFiles__16(templateContent, _) { var deployScriptFileName, deploymentCommand, deployScriptPath, deploymentFilePath, __this = this; var __frame = { name: "ScriptGenerator_prototype_writeDeploymentFiles__16", line: 497 }; return __func(_, this, arguments, ScriptGenerator_prototype_writeDeploymentFiles__16, 1, __frame, function __$ScriptGenerator_prototype_writeDeploymentFiles__16() {
     argNotNull(templateContent, "templateContent");
 
 
@@ -529,7 +535,7 @@ function getTemplatePath(fileName) {
   return path.join(templatesDir, fileName);};
 
 
-function writeContentToFile(path, content, _) { var __frame = { name: "writeContentToFile", line: 532 }; return __func(_, this, arguments, writeContentToFile, 2, __frame, function __$writeContentToFile() { return (function __$writeContentToFile(__then) {
+function writeContentToFile(path, content, _) { var __frame = { name: "writeContentToFile", line: 538 }; return __func(_, this, arguments, writeContentToFile, 2, __frame, function __$writeContentToFile() { return (function __$writeContentToFile(__then) {
 
       if (fs.existsSync(path)) {
         return confirm((("The file: \"" + path) + "\" already exists\nAre you sure you want to overwrite it (y/n): "), __cb(_, __frame, 3, 9, function ___(__0, __2) { var __1 = !__2; return (function __$writeContentToFile(__then) { if (__1) { return _(null); } else { __then(); } ; })(__then); }, true)); } else { __then(); } ; })(function __$writeContentToFile() {

--- a/lib/templates/deploy.bash.functionbasic.template
+++ b/lib/templates/deploy.bash.functionbasic.template
@@ -1,0 +1,76 @@
+# Npm helper
+# ------------
+
+npmPath=`which npm 2> /dev/null`
+if [ -z $npmPath ]
+then
+  NPM_CMD="node \"$NPM_JS_PATH\"" # on windows server there's only npm.cmd
+else
+  NPM_CMD=npm
+fi
+
+##################################################################################################################################
+# Deployment
+# ----------
+
+echo Handling function App deployment.
+
+RunNpm() {
+    echo Restoring npm packages in $1
+
+    pushd $1 > /dev/null
+    eval $NPM_CMD install --production 2>&1
+    exitWithMessageOnError "Npm Install Failed"
+    popd > /dev/null
+}
+
+RestoreNpmPackages() {
+
+    local lookup="package.json"
+    if [ -e "$1/$lookup" ]
+    then
+      RunNpm $1
+    fi
+
+    for subDirectory in "$1"/*
+    do
+      if [ -d $subDirectory ] && [ -e "$subDirectory/$lookup" ]
+      then
+        RunNpm $subDirectory
+      fi
+    done
+}
+
+InstallFunctionExtensions() {
+    echo Installing azure function extensions from nuget
+
+    local lookup="extensions.csproj"
+    if [ -e "$1/$lookup" ]
+    then
+      pushd $1 > /dev/null
+      dotnet build -o bin
+      exitWithMessageOnError "Function extensions installation failed"
+      popd > /dev/null
+    fi
+}
+
+DeployWithoutFuncPack() {
+    echo Not using funcpack because SCM_USE_FUNCPACK is not set to 1
+
+    # 1. Install function extensions
+    InstallFunctionExtensions "$DEPLOYMENT_SOURCE{SitePath}"
+
+    # 2. KuduSync
+    if [[ "$IN_PLACE_DEPLOYMENT" -ne "1" ]]; then
+      "$KUDU_SYNC_CMD" -v 50 -f "$DEPLOYMENT_SOURCE{SitePath}" -t "$DEPLOYMENT_TARGET" -n "$NEXT_MANIFEST_PATH" -p "$PREVIOUS_MANIFEST_PATH" -i ".git;.hg;.deployment;deploy.sh;obj"
+      exitWithMessageOnError "Kudu Sync failed"
+    fi
+
+    # 3. Restore npm
+    RestoreNpmPackages "$DEPLOYMENT_TARGET"
+}
+
+DeployWithoutFuncPack
+# TODO funcpack is not installed on linux machine
+
+##################################################################################################################################

--- a/lib/templates/deploy.batch.functionbasic.template
+++ b/lib/templates/deploy.batch.functionbasic.template
@@ -23,17 +23,20 @@ echo Copying repository files to local storage
 xcopy "%DEPLOYMENT_SOURCE%{SitePath}" "%DEPLOYMENT_TEMP%" /seyiq
 IF !ERRORLEVEL! NEQ 0 goto error
 
-:: 2. Restore npm
+:: 2. Install function extensions
+call :InstallFunctionExtensions "%DEPLOYMENT_TEMP%"
+
+:: 3. Restore npm
 call :RestoreNpmPackages "%DEPLOYMENT_TEMP%"
 
-:: 3. FuncPack
+:: 4. FuncPack
 pushd "%DEPLOYMENT_TEMP%"
 call funcpack pack .
 IF !ERRORLEVEL! NEQ 0 goto error
 popd
 
-:: 4. KuduSync
-call :ExecuteCmd "%KUDU_SYNC_CMD%" -v 50 -f "%DEPLOYMENT_TEMP%" -t "%DEPLOYMENT_TARGET%" -n "%NEXT_MANIFEST_PATH%" -p "%PREVIOUS_MANIFEST_PATH%" -i ".git;.hg;.deployment;deploy.cmd;node_modules"
+:: 5. KuduSync
+call :ExecuteCmd "%KUDU_SYNC_CMD%" -v 50 -f "%DEPLOYMENT_TEMP%" -t "%DEPLOYMENT_TARGET%" -n "%NEXT_MANIFEST_PATH%" -p "%PREVIOUS_MANIFEST_PATH%" -i ".git;.hg;.deployment;deploy.cmd;node_modules;obj"
 IF !ERRORLEVEL! NEQ 0 goto error
 
 exit /b %ERRORLEVEL%
@@ -44,13 +47,16 @@ setlocal
 
 echo Not using funcpack because SCM_USE_FUNCPACK is not set to 1
 
-:: 1. KuduSync
+:: 1. Install function extensions
+call :InstallFunctionExtensions "%DEPLOYMENT_SOURCE%{SitePath}"
+
+:: 2. KuduSync
 IF /I "%IN_PLACE_DEPLOYMENT%" NEQ "1" (
-  call :ExecuteCmd "%KUDU_SYNC_CMD%" -v 50 -f "%DEPLOYMENT_SOURCE%{SitePath}" -t "%DEPLOYMENT_TARGET%" -n "%NEXT_MANIFEST_PATH%" -p "%PREVIOUS_MANIFEST_PATH%" -i ".git;.hg;.deployment;deploy.cmd"
+  call :ExecuteCmd "%KUDU_SYNC_CMD%" -v 50 -f "%DEPLOYMENT_SOURCE%{SitePath}" -t "%DEPLOYMENT_TARGET%" -n "%NEXT_MANIFEST_PATH%" -p "%PREVIOUS_MANIFEST_PATH%" -i ".git;.hg;.deployment;deploy.cmd;obj"
   IF !ERRORLEVEL! NEQ 0 goto error
 )
 
-:: 2. Restore npm
+:: 3. Restore npm
 call :RestoreNpmPackages "%DEPLOYMENT_TARGET%"
 
 exit /b %ERRORLEVEL%
@@ -79,4 +85,17 @@ FOR /F "tokens=*" %%i IN ('DIR /B %1 /A:D') DO (
 
 exit /b %ERRORLEVEL%
 
+:InstallFunctionExtensions
+setlocal
+
+echo Installing function extensions from nuget
+
+IF EXIST "%1\extensions.csproj" (
+  pushd "%1"
+  call dotnet build -o bin
+  IF !ERRORLEVEL! NEQ 0 goto error
+  popd
+)
+
+exit /b %ERRORLEVEL%
 ::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::


### PR DESCRIPTION
writing test for functionApp with extensions deployed to Antares
when kudu on linux have `dotnet 2.0` ready, will also test bash script

`dotnet build -o bin --force --no-incremental` command is the same as [function runtime](https://github.com/fabiocav/azure-webjobs-sdk-script/blob/ca3e1f2ef965d6bc4ab57eb35655c4b38a58d9c0/src/WebJobs.Script/BindingExtensions/ExtensionsManager.cs#L118)

@ahmelsayed is function CLI going to support function app targeting `netstandard`?
I only see `.csx` for C#, if it does I will add a template to build using `dotnet publish`
