### PR TITLE
use msbuild template when projectPath

### DIFF
--- a/lib/generator._js
+++ b/lib/generator._js
@@ -215,10 +215,10 @@ ScriptGenerator.prototype.generateFunctionAppDeploymentScript = function(_) {
   log.info('Generating deployment script for function App');
 
   options = {}
-  if (this.solutionPath) {
-    // if it has a .sln, it must be targeting windows
+  if (this.projectPath) {
     if (this.scriptType == ScriptType.bash) {
-      throw new Error('function app targeting dotnet core is currently not supported');
+      throw new Error('csharp function targeting dotnet core is currently not supported');
+      // TODO add dotnet build template, restrict to function 2.0
     }
     options.solutionPath = fixPathSeparatorToWindows(this.solutionPath);
     options.projectPath = fixPathSeparatorToWindows(this.projectPath);

--- a/lib/generator.js
+++ b/lib/generator.js
@@ -215,10 +215,10 @@ ScriptGenerator.prototype.generateFunctionAppDeploymentScript = function ScriptG
     log.info("Generating deployment script for function App");
 
     options = { }; return (function __$ScriptGenerator_prototype_generateFunctionAppDeploymentScript__4(__then) {
-      if (__this.solutionPath) {
-
+      if (__this.projectPath) {
         if ((__this.scriptType == ScriptType.bash)) {
-          return _(new Error("function app targeting dotnet core is currently not supported")); } ;
+          return _(new Error("csharp function targeting dotnet core is currently not supported")); } ;
+
 
         options.solutionPath = fixPathSeparatorToWindows(__this.solutionPath);
         options.projectPath = fixPathSeparatorToWindows(__this.projectPath);


### PR DESCRIPTION
when function CLI supports csharp function
it is possible to get a `msbuild` template with just a `.csproj` and no `.sln`
in that case, we need a dotnet CLI template to build function 2.0 app (a separate commit)