### PR TITLE
export GOPATH

### DIFF
--- a/lib/templates/deploy.bash.go.template
+++ b/lib/templates/deploy.bash.go.template
@@ -5,9 +5,9 @@
 
 echo Handling Go app deployment.
 
-APPNAME=app
-GOPATH=$DEPLOYMENT_TEMP/go
-APPPATH=$GOPATH/src/$APPNAME
+export APPNAME=app
+export GOPATH=$DEPLOYMENT_TEMP/go
+export APPPATH=$GOPATH/src/$APPNAME
 
 # 1. KuduSync
 mkdir -p $APPPATH


### PR DESCRIPTION
GOPATH needs to be exported on line 9 so it is picked up by the `go get` subprocess on line 23.
For resiliency went ahead and exported the other variables too.