### PR TITLE
Fix go deployment from source

### DIFF
--- a/lib/templates/deploy.bash.go.template
+++ b/lib/templates/deploy.bash.go.template
@@ -6,8 +6,8 @@
 echo Handling Go app deployment.
 
 APPNAME=app
-GOPATH=$DEPLOYMENT_TEMP/go
-APPPATH=$GOPATH/src/$APPNAME
+export GOPATH=$DEPLOYMENT_TEMP/go
+export APPPATH=$GOPATH/src/$APPNAME
 
 # 1. KuduSync
 mkdir -p $APPPATH
@@ -20,7 +20,7 @@ if ls *.toml >/dev/null 2>&1; then
     dep ensure
     exitWithMessageOnError "dep ensure failed"
 else
-    go get ./...
+    go get -v -d ./...
     exitWithMessageOnError "go get failed"
 fi
 
@@ -30,7 +30,7 @@ exitWithMessageOnError "go build failed"
 popd
 
 # 4. KuduSync
-"$KUDU_SYNC_CMD" -v 50 -f "$DEPLOYMENT_TEMP" -t "$DEPLOYMENT_TARGET" -n "$NEXT_MANIFEST_PATH" -p "$PREVIOUS_MANIFEST_PATH" -i ".git;.hg;.deployment;deploy.sh"
+"$KUDU_SYNC_CMD" -v 50 -f "$APPPATH" -t "$DEPLOYMENT_TARGET" -n "$NEXT_MANIFEST_PATH" -p "$PREVIOUS_MANIFEST_PATH" -i ".git;.hg;.deployment;deploy.sh"
 exitWithMessageOnError "Kudu Sync failed"
 
 


### PR DESCRIPTION
 - export necessary env variables
 - don't install named dependency through go get
 - copy only the app content during binplacing