### PR TITLE
Update PHP template to use "correct" test for $COMPOSER_ARGS

### DIFF
--- a/lib/templates/deploy.bash.php.template
+++ b/lib/templates/deploy.bash.php.template
@@ -2,7 +2,7 @@
 # -----------
 
 initializeDeploymentConfig() {
-	if [ ! -e "$COMPOSER_ARGS" ]; then
+	if [ ! -n "$COMPOSER_ARGS" ]; then
     COMPOSER_ARGS="--no-interaction --prefer-dist --optimize-autoloader --no-progress --no-dev --verbose"
     echo "No COMPOSER_ARGS variable declared in App Settings, using the default settings"
   else


### PR DESCRIPTION
I ran into this issue recently trying to get a Drupal deployment happening.  
Pushing to git was resulting in Kudu ignoring the COMPOSER_ARGS environment variable.  I noticed that the other empty variable checks in the resulting deploy.sh script use "-n" instead of "-e".  Making the above change to my deploy.sh script fixed the issue for my deployments.